### PR TITLE
Workflows/auto formatting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("java")
+    id("com.diffplug.spotless") version "6.23.3"
 }
 
 group = "no.elixir"
@@ -16,4 +17,27 @@ dependencies {
 
 tasks.test {
     useJUnitPlatform()
+}
+
+allprojects {
+    apply(plugin = "com.diffplug.spotless")
+
+    spotless {
+        format("misc") {
+            target("**/*.gradle", ".gitattributes", ".gitignore")
+
+            // define the steps to apply to those files
+            trimTrailingWhitespace()
+            indentWithTabs() // or spaces. Takes an integer argument if you don't like 4
+            endWithNewline()
+        }
+
+        java {
+            importOrder()
+            removeUnusedImports()
+            cleanthat()
+            googleJavaFormat()
+            formatAnnotations()
+        }
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,20 +4,17 @@ plugins {
 }
 
 group = "no.elixir"
+
 version = "1.0-SNAPSHOT"
 
-repositories {
-    mavenCentral()
-}
+repositories { mavenCentral() }
 
 dependencies {
     testImplementation(platform("org.junit:junit-bom:5.9.1"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }
 
-tasks.test {
-    useJUnitPlatform()
-}
+tasks.test { useJUnitPlatform() }
 
 allprojects {
     apply(plugin = "com.diffplug.spotless")
@@ -28,10 +25,9 @@ allprojects {
 
             // define the steps to apply to those files
             trimTrailingWhitespace()
-            indentWithTabs() // or spaces. Takes an integer argument if you don't like 4
+            indentWithTabs()  // or spaces. Takes an integer argument if you don't like 4
             endWithNewline()
         }
-
         java {
             importOrder()
             removeUnusedImports()
@@ -39,5 +35,12 @@ allprojects {
             googleJavaFormat()
             formatAnnotations()
         }
+    }
+
+    configure<com.diffplug.gradle.spotless.SpotlessExtension> {
+        kotlin {
+            diktat()
+        }
+        kotlinGradle { diktat() }
     }
 }


### PR DESCRIPTION
This PR should enhance our development processes by adding a formatter which works regardless of whether an IDE is setup for it or not.

The spotless Gradle plugin allows one to execute `./gradlew spotlessCheck` and `./gradlew spotlessApply` to check and apply the defined formatting rules in the root `build.gradle.kts` file. The current configuration uses Google's java formatting style for Java code and `diktat` for Kotlin and Gradle files using the Kotlin DSL. 

How this get's enforced should be discussed. 