### PR TITLE
Add new plugins and build conventions for SpringBoot applications

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -11,6 +11,10 @@ repositories {
 dependencies {
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.23.3")
     implementation("org.ow2.asm:asm:8.0.1")
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.2.0")
+    implementation("io.spring.gradle:dependency-management-plugin:1.1.4")
+    implementation("org.hibernate.orm:hibernate-gradle-plugin:6.3.1.Final")
+    implementation("org.graalvm.buildtools:native-gradle-plugin:0.9.28")
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/kotlin/springboot-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/springboot-conventions.gradle.kts
@@ -1,0 +1,37 @@
+plugins {
+    java
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+    id("org.hibernate.orm")
+    id("org.graalvm.buildtools.native")
+    id("formatting-conventions")
+}
+
+java { sourceCompatibility = JavaVersion.VERSION_17 }
+
+configurations {
+    compileOnly {
+        extendsFrom(configurations.annotationProcessor.get())
+    }
+}
+
+repositories { mavenCentral() }
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    compileOnly("org.projectlombok:lombok")
+    developmentOnly("org.springframework.boot:spring-boot-devtools")
+    developmentOnly("org.springframework.boot:spring-boot-docker-compose")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+    annotationProcessor("org.projectlombok:lombok")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<Test> { useJUnitPlatform() }
+
+hibernate {
+    enhancement {
+        enableAssociationManagement.set(true)
+    }
+}


### PR DESCRIPTION
Added new dependencies to the build.gradle.kts file which include Spring Boot, Hibernate, among others. Also, a new build conventions file, springboot-conventions.gradle.kts, has been created to manage plugin configurations, dependencies, tasks and other settings related to SpringBoot applications.