### PR TITLE
Add okhttp and jsonwebtoken plugins

### DIFF
--- a/buildSrc/src/main/kotlin/okhttp.gradle.kts
+++ b/buildSrc/src/main/kotlin/okhttp.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    java
+}
+
+repositories { mavenCentral() }
+
+dependencies {
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+}

--- a/lib/clearinghouse/build.gradle.kts
+++ b/lib/clearinghouse/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("maven-publish")
     id("io.freefair.lombok") version "8.4"
     id("formatting-conventions")
+    id("jsonwebtoken")
+    id("okhttp")
 }
 
 group = "no.elixir"
@@ -18,18 +20,13 @@ java {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.apache.commons:commons-collections4:4.4")
     implementation("org.apache.commons:commons-lang3:3.14.0")
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.auth0:jwks-rsa:0.22.1")
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
     implementation("org.slf4j:slf4j-jdk14:2.0.11")
-    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
-    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.bouncycastle:bcprov-jdk15to18:1.77")
     testImplementation("org.bouncycastle:bcpkix-jdk15to18:1.77")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.4")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
 }

--- a/services/tsd-api-mock/build.gradle.kts
+++ b/services/tsd-api-mock/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("springboot-conventions")
+    id("jsonwebtoken")
 }
 
 group = "no.elixir"
@@ -7,10 +8,7 @@ version = "1.0-SNAPSHOT"
 
 dependencies {
     runtimeOnly("com.h2database:h2")
-    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
     implementation("org.apache.commons:commons-lang3:3.14.0")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
 }
 
 tasks.test {


### PR DESCRIPTION
This update adds the okhttp and jsonwebtoken plugins to the build file of 'clearinghouse' and 'tsd-api-mock' respectively. It also moves the okhttp dependencies to a separate okhttp.gradle.kts file for better code organization and dependency management.

Fixes #79 