### PR TITLE
[GH-action] Add caching for Go dependencies in GitHub workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,6 +31,9 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: 'stable'
+          cache-dependency-path: |
+            cli/lega-commander/go.sum
+            services/mq-interceptor/go.sum
 
       - name: Cache gradle packages
         uses: actions/cache@v4


### PR DESCRIPTION
Enhanced the GitHub Action workflow by specifying Go dependencies to be cached. This change aims to speed up the build process reduce bandwidth consumption.

Fixes #108 