### PR TITLE
Revert "fix: unable to fully assemble modules when starting the orchestration "

### DIFF
--- a/e2eTests/README.md
+++ b/e2eTests/README.md
@@ -6,23 +6,8 @@ of how this setup works.
 
 ![FEGA Norway E2E Test Setup Module](figure-1.png)
 
-[Edit and export this figure at tldraw.com](https://www.tldraw.com/r/hQuNVXYht2-H6QRZcMh28?v=-3234,-969,4361,2023&p=page)
+[Edit this figure at tldraw.com](https://www.tldraw.com/r/hQuNVXYht2-H6QRZcMh28?v=-3234,-969,4361,2023&p=page)
 
-# Prerequisites
-
-1. [Install `docker`](https://docs.docker.com/engine/install/ubuntu/).
-   - You must be able to run `docker` and `docker compose` without sudo
-2. [Install `docker compose`](https://docs.docker.com/compose/install/) (usually it is bundled with Docker).
-3. [Install Golang](https://go.dev/doc/install)
-   - `curl -OJL https://go.dev/dl/go1.22.2.linux-amd64.tar.gz`
-   - `rm -rf /usr/local/go && tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz`
-   - `export PATH=$PATH:/usr/local/go/bin`
-4. [Install Java](https://www.java.com/en/download/help/download_options.html)
-   - `sudo apt update`
-   - `sudo apt install openjdk-21-jdk`
-   - `echo "export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64/" >> ~/.bashrc`
-5. Make sure you have at least `8GiB` of free space on your machine.
- 
 # How to run the setup?
 
 **To start the orchestration:**
@@ -41,80 +26,60 @@ of how this setup works.
 
 If the orchestration fail to start for some reason. We suggest trying the fixes below.
 
-<details>
-  <summary>I have conflicting containers. How do I remove them?</summary>
+##### Unable to execute `start-docker-containers`?
+
+1. Ensure `docker` is installed.
+2. Ensure `docker-compose` (V2) is installed.
+
+##### Remove stale containers
 
 If for some reason it complaints about conflicting container
-names, we suggest you manually remove those.
+names, we suggest you manually remove the existing containers.
 
 ```bash
 docker rm tsd db mq proxy interceptor postgres ingest verify finalize mapper doa cegamq cegaauth
 ```
-</details>
 
-<details>
-  <summary>Docker complaints about port issues when running</summary>
+##### Open ports issues
 
-The following ports **must** be free when running the setup.
+The following ports **must** be free when running the setup. 
 `5432 5672 5433 80 5673 15672 25672` if any other service is
 running please make sure you stop them.
 
 ```bash
-lsof -ti:5432 -ti:5672 -ti:5433 -ti:80 -ti:5673 -ti:15672 -ti:25672 | xargs kill -9
+for port in 5432 5672 5433 80 5673 15672 25672; do lsof -ti:$port | xargs kill -9; done
 ```
-</details>
 
-<details>
-  <summary>I made changes in `services/` but when I run latest are not there in the build</summary>
-
-Try removing the stale images.
+##### Remove stale images
 
 ```bash
 docker rmi tsd-proxy:latest tsd-api-mock:latest mq-interceptor:latest --force
 ```
-</details>
 
-<details>
-  <summary>I have `docker-compose` but I can't find `docker compose` command?</summary>
+##### Docker Compose issues
 
-In some cases, particularly on older Ubuntu distributions, you might find that you have `docker-compose` (V2) installed but not the `docker compose` subcommand. To resolve this, first ensure you have Compose V2 and then, you can create a symbolic link in the `cli-plugins` directory by executing the following commands:
+First, verify that `docker compose` is correctly installed. Ensure you have Compose V2.
+
+For migration guidance to Docker Compose, visit [migrate to docker compose](https://docs.docker.com/compose/migrate/).
+
+In some cases, particularly on older Ubuntu distributions, you might find that you have `docker-compose` (V2) installed but not the `docker compose` subcommand. To resolve this, you can create a symbolic link in the `cli-plugins` directory by executing the following commands:
 
 ```bash
 mkdir -p ~/.docker/cli-plugins
 ln -sfn /usr/local/bin/docker-compose ~/.docker/cli-plugins/docker-compose
 ```
 
-For migration guidance to Docker Compose, visit [migrate to docker compose](https://docs.docker.com/compose/migrate/). Also, for further discussions and troubleshooting, refer to the GitHub issue at https://github.com/docker/compose/issues/8630.
-</details>
+For further discussions and troubleshooting, refer to the GitHub issue at https://github.com/docker/compose/issues/8630.
 
-<details>
-  <summary>Docker fails to build mq-interceptor (dial tcp: lookup proxy.golang.org: i/o timeout) </summary>
+##### Maybe try cleaning everything?
 
-Do a docker daemon restart.
-
-```bash
-sudo systemctl restart docker
-```
-</details>
-
-<details>
-  <summary>I made a mess. I want to start from scratch.</summary>
-
-First, clean the e2eTests directory and all the submodules.
-
-```bash
-sudo rm -rf e2eTests/tmp e2eTests/bin docker-compose.yml &&
-./gradlew clean
-```
-
-And then let's prune the docker system and restarts the docker daemon.
+This prunes the docker system and restarts the docker daemon.
 
 ```bash
 docker stop $(docker ps -aq) && \
 docker rm $(docker ps -aq) && \
 docker rmi tsd-proxy:latest tsd-api-mock:latest mq-interceptor:latest --force && \
-lsof -ti:5432 -ti:5672 -ti:5433 -ti:80 -ti:5673 -ti:15672 -ti:25672 | xargs kill -9 \
+for port in 5432 5672 5433 80 5673 15672 25672; do lsof -ti:$port | xargs kill -9; done && \
 echo 'y' | docker system prune &&
 sudo systemctl restart docker
 ```
-</details>

--- a/e2eTests/build.gradle.kts
+++ b/e2eTests/build.gradle.kts
@@ -34,8 +34,13 @@ tasks.register<Exec>("cleanup") {
     commandLine("sh", "-c", "./setup.sh clean")
 }
 
-tasks.register<Exec>("initialize") {
+tasks.register<Exec>("project-cleanup") {
     dependsOn("cleanup")
+    commandLine("../gradlew", "clean")
+}
+
+tasks.register<Exec>("initialize") {
+    dependsOn("project-cleanup")
     commandLine("sh", "-c", "./setup.sh init")
 }
 
@@ -49,8 +54,13 @@ tasks.register<Exec>("apply-configs") {
     commandLine("sh", "-c", "./setup.sh apply_configs")
 }
 
-tasks.register<Exec>("start-docker-containers") {
+tasks.register<Exec>("assemble-project") {
     dependsOn("apply-configs")
+    commandLine("../gradlew", "assemble")
+}
+
+tasks.register<Exec>("start-docker-containers") {
+    dependsOn("assemble-project")
     commandLine("docker", "compose", "up", "-d")
 }
 
@@ -60,8 +70,8 @@ tasks.register<Exec>("stop-docker-containers") {
 
 tasks.test {
     useJUnitPlatform()
-//    dependsOn("start-docker-containers")
-//    finalizedBy("stop-docker-containers")
+    dependsOn("start-docker-containers")
+    finalizedBy("stop-docker-containers")
     // Ensure this test runs only after all other
     // test tasks are completed
     mustRunAfter(

--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -15,7 +15,7 @@ services:
   db:
     container_name: db
     hostname: db
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47-postgres
+    image: ghcr.io/neicnordic/sensitive-data-archive:sha-5334501063d8cdd62594fcc045914f501a7a4026-postgres
     ports:
       - "5432:5432"
     environment:
@@ -125,7 +125,7 @@ services:
   ingest:
     container_name: ingest
     hostname: ingest
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    image: ghcr.io/neicnordic/sensitive-data-archive:sha-5334501063d8cdd62594fcc045914f501a7a4026
     depends_on:
       db:
         condition: service_healthy
@@ -173,7 +173,7 @@ services:
   verify:
     container_name: verify
     hostname: verify
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    image: ghcr.io/neicnordic/sensitive-data-archive:sha-5334501063d8cdd62594fcc045914f501a7a4026
     depends_on:
       db:
         condition: service_healthy
@@ -220,7 +220,7 @@ services:
   finalize:
     container_name: finalize
     hostname: finalize
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    image: ghcr.io/neicnordic/sensitive-data-archive:sha-5334501063d8cdd62594fcc045914f501a7a4026
     depends_on:
       db:
         condition: service_healthy
@@ -258,7 +258,7 @@ services:
   mapper:
     container_name: mapper
     hostname: mapper
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    image: ghcr.io/neicnordic/sensitive-data-archive:sha-5334501063d8cdd62594fcc045914f501a7a4026
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
Reverts ELIXIR-NO/FEGA-Norway#144

Sorry for not catching this sooner, but would like to make some changes to the readme. While the instructions here seem fine, they are hyper centric towards Debian and it's derivates. All the modules we have are supported in all OS and even across architectures. It's best to just point to official docs and let the developer do what they need to do to get things setup on their system.