### PR TITLE
Fix setup of formatter

### DIFF
--- a/.github/workflows/Format-code.yml
+++ b/.github/workflows/Format-code.yml
@@ -46,9 +46,11 @@ jobs:
 
       - name: Commit and Push Changes
         if: steps.format.outputs.changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
           git add -A
           git commit -m "Code formatting applied"
-          git push origin HEAD
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/ELIXIR-NO/FEGA-Norway.git HEAD:main


### PR DESCRIPTION
The current setup fails due to 2 issues:
1. HEAD wasn't explicitly specified
2. There needs to be an explicit GitHub token with needed rights to allow for commits to work.