### PR TITLE
Import sda-doa as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "services/sda-doa"]
+	path = services/sda-doa
+	url = https://github.com/neicnordic/sda-doa.git


### PR DESCRIPTION
Fixes #181 

Imports `sda-doa` a git submodule into the mono-repo. Keeps the project isolated and still under neicnordic repository but allows for building and testing with the rest of the stack.