### PR TITLE
Update Opcodes.V9 to V21 to be compatible with Java 21

### DIFF
--- a/buildSrc/src/main/java/org/gradle/transform/javamodules/ExtraModuleInfoTransform.java
+++ b/buildSrc/src/main/java/org/gradle/transform/javamodules/ExtraModuleInfoTransform.java
@@ -62,7 +62,7 @@ abstract public class ExtraModuleInfoTransform implements TransformAction<ExtraM
 
     private static byte[] addModuleInfo(ModuleInfo moduleInfo) {
         ClassWriter classWriter = new ClassWriter(0);
-        classWriter.visit(Opcodes.V9, Opcodes.ACC_MODULE, "module-info", null, null, null);
+        classWriter.visit(Opcodes.V21, Opcodes.ACC_MODULE, "module-info", null, null, null);
         ModuleVisitor moduleVisitor = classWriter.visitModule(moduleInfo.getModuleName(), Opcodes.ACC_OPEN, moduleInfo.getModuleVersion());
         for (String packageName : moduleInfo.getExports()) {
             moduleVisitor.visitExport(packageName.replace('.', '/'), 0);


### PR DESCRIPTION
we recently upgraded the version of asm and the new version has opcodes for java up to 23 (we are currently using 21)
https://asm.ow2.io/versions.html