### PR TITLE
Implicit narrowing conversion in compound assignment

### DIFF
--- a/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java
+++ b/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java
@@ -30,7 +30,7 @@ class Crypt4GHInputStreamInternal extends FilterInputStream {
   private Optional<DataEditList> dataEditList;
 
   private int encryptedSegmentSize;
-  private int lastDecryptedSegment = -1;
+  private long lastDecryptedSegment = -1;
 
   /**
    * Constructs the internal part of Crypt4GHInputStream that wraps existing InputStream, not a
@@ -134,10 +134,12 @@ class Crypt4GHInputStreamInternal extends FilterInputStream {
     long delta = newDecryptedPosition - currentDecryptedPosition;
     if (bytesRead + delta > buffer.length) {
       long missingBytes = bytesRead + delta - buffer.length;
-      bytesRead += (delta - missingBytes);
+      assert bytesRead + delta - missingBytes <= Integer.MAX_VALUE : "Value assigned to int exceeds integer range";
+      bytesRead = (int)(bytesRead + delta - missingBytes);
       return n - missingBytes;
     }
-    bytesRead += delta;
+    assert bytesRead + delta <= Integer.MAX_VALUE : "Value assigned to int exceeds integer range";
+    bytesRead = (int)(bytesRead + delta);
     return n;
   }
 

--- a/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java
+++ b/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java
@@ -134,12 +134,13 @@ class Crypt4GHInputStreamInternal extends FilterInputStream {
     long delta = newDecryptedPosition - currentDecryptedPosition;
     if (bytesRead + delta > buffer.length) {
       long missingBytes = bytesRead + delta - buffer.length;
-      assert bytesRead + delta - missingBytes <= Integer.MAX_VALUE : "Value assigned to int exceeds integer range";
-      bytesRead = (int)(bytesRead + delta - missingBytes);
+      assert bytesRead + delta - missingBytes <= Integer.MAX_VALUE
+          : "Value assigned to int exceeds integer range";
+      bytesRead = (int) (bytesRead + delta - missingBytes);
       return n - missingBytes;
     }
     assert bytesRead + delta <= Integer.MAX_VALUE : "Value assigned to int exceeds integer range";
-    bytesRead = (int)(bytesRead + delta);
+    bytesRead = (int) (bytesRead + delta);
     return n;
   }
 


### PR DESCRIPTION
This PR tries to address CodeQL's complaints about "Implicit narrowing conversion in compound assignment"

- [#1](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/1)
- [#2](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/2)
- [#3](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/3)

The `lastDecryptedSegment` field mentioned in [#3](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/3) is changed from an `int` to a `long`. According to the [Crypt4GH specification](https://samtools.github.io/hts-specs/crypt4gh.pdf), the IETF-version of the ChaCha20 cipher uses a 32-bit block counter, so representing blocks/segments with a signed integer (32 bits in Java) may not be sufficient anyway.

The `bytesRead` field in [#1](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/1) and [#2](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/2) is used as an array index for the [`buffer`](https://github.com/ELIXIR-NO/FEGA-Norway/blob/3fae9f5c215cb5e9a2ff26d40421640e8325af13/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java#L79) array, so it must remain an `int`.

Since the if-block on [line 135](https://github.com/ELIXIR-NO/FEGA-Norway/blob/3fae9f5c215cb5e9a2ff26d40421640e8325af13/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java#L135) ends with a [return-statement](https://github.com/ELIXIR-NO/FEGA-Norway/blob/3fae9f5c215cb5e9a2ff26d40421640e8325af13/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java#L138) that is always executed if the expression `(bytesRead + delta > buffer.length)` holds true, [line 140](https://github.com/ELIXIR-NO/FEGA-Norway/blob/3fae9f5c215cb5e9a2ff26d40421640e8325af13/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java#L140) in the old code (142 in new) is an implicit else-clause that is only executed if the expression is false (i.e. `bytesRead + delta <= buffer.length`) . Since `buffer.length` is an integer and the new value (bytesRead+delta) is equal or less, the value of bytesRead after the assignment must also be an integer.

Also, I'm pretty sure that the expression on [line 137](https://github.com/ELIXIR-NO/FEGA-Norway/blob/3fae9f5c215cb5e9a2ff26d40421640e8325af13/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/stream/Crypt4GHInputStreamInternal.java#L137) in the old code (138 in new code) just sets `bytesRead` to `buffer.length`, which is an integer already. So that assignment could potentially be simplified to avoid [#1](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/1) altogether.

I have not verified that this will actually satisfy CodeQL's complaints.