### PR TITLE
feat: Add `rawToken` Field to Visa with temp Security Measures

### DIFF
--- a/lib/clearinghouse/src/main/java/no/uio/ifi/clearinghouse/Clearinghouse.java
+++ b/lib/clearinghouse/src/main/java/no/uio/ifi/clearinghouse/Clearinghouse.java
@@ -154,6 +154,7 @@ public enum Clearinghouse {
         String visaJson = new Gson().toJson(claims.get(GA_4_GH_VISA_V_1));
         Visa visa = new Gson().fromJson(visaJson, Visa.class);
         visa.setSub(jws.getPayload().getSubject());
+        visa.setRawToken(visaToken);
         return Optional.of(visa);
       }
     } catch (SignatureException e) {

--- a/lib/clearinghouse/src/main/java/no/uio/ifi/clearinghouse/model/Visa.java
+++ b/lib/clearinghouse/src/main/java/no/uio/ifi/clearinghouse/model/Visa.java
@@ -26,4 +26,15 @@ public class Visa {
   private List<List<Map<?, ?>>> conditions; // conditions
 
   private String by; // by identifier
+
+  /**
+   * The raw token required for APIs above the Clearing House to delegate tasks to other services
+   * (such as SDA and DOA). This field is marked as transient to prevent it from being serialized
+   * and exposed unintentionally during object serialization processes. The token is necessary for
+   * internal operations but should not be persisted or transmitted in insecure contexts.
+   *
+   * <p>FIXME: We need to remove this in the future to enhance security and ensure sensitive
+   * information is not exposed.
+   */
+  @ToString.Exclude private transient String rawToken;
 }


### PR DESCRIPTION
This PR introduces the `rawToken` field to the Visa POJO to facilitate delegation of tasks by APIs above the Clearing House to external services (such as SDA and DOA). To mitigate security risk associated with this sensitive field:

The rawToken field has been marked as transient to prevent unintended serialization. `@ToString.Exclude` is used to ensure it is not exposed in logs or debug outputs.

**Notes:**
The addition of `rawToken` is a temporary solution. We need to explore alternative designs to eliminate this field from the POJO entirely while maintaining functionality for task delegation. This PR provides an immediate workaround to secure sensitive data until a long-term solution is implemented.