### PR TITLE
Enable static builds for lega-commander to resolve glibc compatibility issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,7 @@ jobs:
           workdir: cli/lega-commander
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CGO_ENABLED: "0"
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Modified the `publish-lega-commander` step in the GitHub Actions workflow to include: `CGO_ENABLED=0` in the environment variables.

This should ensured portability by eliminating runtime dependencies on shared libraries.