### PR TITLE
Add version attribute to Crypt4GH Manifest file

### DIFF
--- a/lib/crypt4gh/build.gradle.kts
+++ b/lib/crypt4gh/build.gradle.kts
@@ -33,6 +33,17 @@ tasks.test {
     useJUnitPlatform()
 }
 
+tasks.jar {
+    manifest {
+        attributes(
+            "Implementation-Title" to project.name,
+            "Implementation-Version" to project.version,
+            "Implementation-Vendor" to "Elixir Norway",
+            "Main-Class" to "no.elixir.crypt4gh.app.Main"
+        )
+    }
+}
+
 publishing {
     publications {
         create<MavenPublication>("mavenJava") {


### PR DESCRIPTION
This PR addresses issue [#353](https://github.com/ELIXIR-NO/FEGA-Norway/issues/353) and adds a few attributes to the MANIFEST.MF file inside the Crypt4GH JAR-file, including the `Implementation-Version` attribute that is read and displayed by the [printVersion()](https://github.com/ELIXIR-NO/FEGA-Norway/blob/da15236d7ca203c4479d05555136bcdb2a5f8730/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/app/Main.java#L102-L105) method.

The value for "Implementation-Version" is based on the Gradle variable named `version` (aka `project.version`), which used to be set directly in the Gradle build file ([example](https://github.com/ELIXIR-NO/FEGA-Norway/commit/c0d3b08fd302434b7f32681a6ce1a6545ab9e03a)). This has since been removed, and the version is now instead specified with the command-line argument `-Pversion=<version>` when the component is [built or published in the release workflow](https://github.com/ELIXIR-NO/FEGA-Norway/blob/da15236d7ca203c4479d05555136bcdb2a5f8730/.github/workflows/release.yml#L100-L101).

The new functionality has been tested locally by running the command `./gradlew lib:crypt4gh:build -Pversion=13.1.7`. This lead to the creation of a JAR-file named "crypt4gh-13.1.7.jar" containing the following MANIFEST.MF file. (The last four lines were added by the new code in this commit.)

```
Manifest-Version: 1.0
Implementation-Title: crypt4gh
Implementation-Version: 13.1.7
Implementation-Vendor: Elixir Norway
Main-Class: no.elixir.crypt4gh.app.Main
``` 

Running Crypt4GH with the `-v` option also displayed the correct version, whereas previously the version displayed would be "null". 

It has not been tested with the full release workflow.