### PR TITLE
add cega-mock and tsd-api-client to build image workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -4,6 +4,8 @@ on:
     paths:
       - 'services/localega-tsd-proxy/**'
       - 'services/mq-interceptor/**'
+      - 'services/cega-mock/**'
+      - 'services/tsd-api-mock/**'
     branches:
       - main
 
@@ -13,6 +15,8 @@ jobs:
     outputs:
       localega-tsd-proxy: ${{ steps.changes.outputs.localega-tsd-proxy }}
       mq-interceptor: ${{ steps.changes.outputs.mq-interceptor }}
+      cega-mock: ${{ steps.changes.outputs.cega-mock }}
+      tsd-api-mock: ${{ steps.changes.outputs.tsd-api-mock }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -23,8 +27,10 @@ jobs:
               - 'services/localega-tsd-proxy/**'
             mq-interceptor:
               - 'services/mq-interceptor/**'
-  
-  
+            cega-mock:
+              - 'services/cega-mock/**'
+            tsd-api-mock:
+              - 'services/tsd-api-mock/**'
 
   localega_tsd_proxy:
     needs: detect-changes
@@ -97,4 +103,71 @@ jobs:
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             org.opencontainers.image.revision=${{ github.sha }}
-     
+
+    cega-mock:
+      needs: detect-changes
+      if: needs.detect-changes.outputs.cega-mock == 'true'
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+        packages: write
+      steps:
+        - uses: actions/checkout@v4
+        - name: Set Repository Name
+          id: repo_name
+          run: |
+            REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+            echo "repo_name=$REPO_NAME" >> $GITHUB_ENV
+        - name: Log in to the Github Container registry
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build and push
+          uses: docker/build-push-action@v6
+          with:
+            context: ./services/cega-mock
+            push: true
+            no-cache: 'true'
+            tags: |
+              ghcr.io/${{ env.repo_name }}:cega-mock-${{ github.event.number }}
+            labels: |
+              org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+              org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+              org.opencontainers.image.revision=${{ github.sha }}
+
+    tsd-api-mock:
+      needs: detect-changes
+      if: needs.detect-changes.outputs.tsd-api-mock == 'true'
+      runs-on: ubuntu-latest
+      permissions:
+        contents: write
+        packages: write
+      steps:
+        - uses: actions/checkout@v4
+        - name: Build with Gradle
+          run: ./gradlew services:tsd-api-mock:assemble
+        - name: Set Repository Name
+          id: repo_name
+          run: |
+            REPO_NAME=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+            echo "repo_name=$REPO_NAME" >> $GITHUB_ENV
+        - name: Log in to the Github Container registry
+          uses: docker/login-action@v3
+          with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+        - name: Build and push
+          uses: docker/build-push-action@v6
+          with:
+            context: ./services/tsd-api-mock
+            push: true
+            no-cache: 'true'
+            tags: |
+              ghcr.io/${{ env.repo_name }}:tsd-api-mock-${{ github.event.number }}
+            labels: |
+              org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+              org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+              org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
we build our images when we open/update a pr, to ensure proposed changes don't break the images build process and images build without errors.
we were mising cega-mock and tsd-api-client, now they are added.