### PR TITLE
Change codeql trigger from pr to push

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,16 +1,12 @@
 name: "CodeQL"
 
 on:
-  pull_request:
-    branches: [ "main" ]
-    types:
-      - closed
-  schedule:
-    - cron: '00 9 * * 1'
+  push:
+    branches:
+      - main
 
 jobs:
   analyze:
-    if: github.event.pull_request.merged == true
     name: Analyze
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}


### PR DESCRIPTION
This PR updates the CodeQL workflow to trigger on push to main, ensuring that the code is analyzed on every push to main. It resolves the "MissingPushHook" warning and enables code scanning alerts to be displayed on the Security tab of GitHub. 

Actual warning:
_Warning: 1 issue was detected with this workflow: Please specify an on.push hook to analyze and see code scanning alerts from the default branch on the Security tab.
  Warning: Unable to validate code scanning workflow: MissingPushHook_