### PR TITLE
update Go toolchain version to 1.24.0 to match the required syntax

### DIFF
--- a/cli/lega-commander/go.mod
+++ b/cli/lega-commander/go.mod
@@ -1,6 +1,6 @@
 module github.com/ELIXIR-NO/FEGA-Norway/cli/lega-commander
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/buger/jsonparser v1.1.1

--- a/services/cega-mock/go.mod
+++ b/services/cega-mock/go.mod
@@ -1,3 +1,3 @@
 module github.com/ELIXIR-NO/FEGA-Norway/services/cega-mock
 
-go 1.24
+go 1.24.0

--- a/services/mq-interceptor/go.mod
+++ b/services/mq-interceptor/go.mod
@@ -1,6 +1,6 @@
 module github.com/ELIXIR-NO/FEGA-Norway/mq-interceptor
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/lib/pq v1.10.9


### PR DESCRIPTION
This PR updates the Go toolchain version in go.mod in mq-interceptor, cega-mock and lega-cmdr to use the correct 1.N.P syntax to resolve the warning from codeql