### PR TITLE
Replace Auth0 JWT.decode with JJWT decoding

### DIFF
--- a/lib/tsd-file-api-client/build.gradle.kts
+++ b/lib/tsd-file-api-client/build.gradle.kts
@@ -18,8 +18,11 @@ dependencies {
 
     implementation("org.apache.commons:commons-lang3:3.17.0")
     implementation("commons-io:commons-io:2.18.0")
-    implementation("com.auth0:java-jwt:4.5.0")
     implementation("com.google.code.gson:gson:2.12.1")
+
+    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    implementation("io.jsonwebtoken:jjwt-impl:0.12.3")
+    implementation("io.jsonwebtoken:jjwt-jackson:0.12.3")
 
     api("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("org.slf4j:slf4j-jdk14:2.0.17")


### PR DESCRIPTION
This change replaces the Auth0 JWT library with JJWT for token decoding.

Before with Auth0, decoding the token was a single-line operation that extracted the claim. To switch to JJWT, I broke it into building a parser, parsing the token, extracting the claims, and then formatting the endpoint. 

These changes keep the functionality that we had with Auth0. However, JJWT seems to be designed to enforce token verification, so implementing that might have been the original idea? @joshbaskaran ?