### PR TITLE
feat: implement external changelog generation system for components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     types:
       - closed
 
@@ -43,8 +43,7 @@ jobs:
               - 'services/mq-interceptor/**'
             tsd-api-mock:
               - 'services/tsd-api-mock/**'
-  
-  
+
   get-new-tag-clearinghouse:
     needs: detect-changes
     if: needs.detect-changes.outputs.clearinghouse == 'true'
@@ -58,8 +57,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
       - name: Bump patch version for clearinghouse
         id: bump_clearinghouse_version
         run: echo "new_clearinghouse_version=${{ needs.get-new-tag-clearinghouse.outputs.new_version }}" >> $GITHUB_OUTPUT
@@ -69,12 +68,17 @@ jobs:
           ./gradlew :lib:clearinghouse:publish -Pversion=${{ steps.bump_clearinghouse_version.outputs.new_clearinghouse_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :lib:clearinghouse:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "clearinghouse-${{ steps.bump_clearinghouse_version.outputs.new_clearinghouse_version }}"
+          body_path: /tmp/changelogs/clearinghouse.md
           prerelease: false
 
   get-new-tag-crypt4gh:
@@ -90,8 +94,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
       - name: Bump patch version for crypt4gh
         id: bump_crypt4gh_version
         run: echo "new_crypt4gh_version=${{ needs.get-new-tag-crypt4gh.outputs.new_version }}" >> $GITHUB_OUTPUT
@@ -101,12 +105,17 @@ jobs:
           ./gradlew :lib:crypt4gh:publish -Pversion=${{ steps.bump_crypt4gh_version.outputs.new_crypt4gh_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :lib:crypt4gh:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "crypt4gh-${{ steps.bump_crypt4gh_version.outputs.new_crypt4gh_version }}"
+          body_path: /tmp/changelogs/crypt4gh.md
           prerelease: false
 
   get-new-tag-tsd-file-api-client:
@@ -122,8 +131,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
       - name: Bump patch version for tsd-file-api-client
         id: bump_tsd_file_api_client_version
         run: echo "new_tsd_file_api_client_version=${{ needs.get-new-tag-tsd-file-api-client.outputs.new_version }}" >> $GITHUB_OUTPUT
@@ -133,12 +142,17 @@ jobs:
           ./gradlew :lib:tsd-file-api-client:publish -Pversion=${{ steps.bump_tsd_file_api_client_version.outputs.new_tsd_file_api_client_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :lib:tsd-file-api-client:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "tsd-file-api-client-${{ steps.bump_tsd_file_api_client_version.outputs.new_tsd_file_api_client_version }}"
+          body_path: /tmp/changelogs/tsd-file-api-client.md
           prerelease: false
 
   get-new-tag-localega-tsd-proxy:
@@ -170,12 +184,17 @@ jobs:
           docker pull ghcr.io/${{ env.repo_name }}:localega-tsd-proxy-${{ github.event.number }}
           docker tag ghcr.io/${{ env.repo_name }}:localega-tsd-proxy-${{ github.event.number }} ghcr.io/${{ env.repo_name }}:localega-tsd-proxy-${{ steps.bump_localega_tsd_proxy_version.outputs.new_localega_tsd_proxy_version }}
           docker push ghcr.io/${{ env.repo_name }}:localega-tsd-proxy-${{ steps.bump_localega_tsd_proxy_version.outputs.new_localega_tsd_proxy_version }}
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :services:localega-tsd-proxy:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "localega-tsd-proxy-${{ steps.bump_localega_tsd_proxy_version.outputs.new_localega_tsd_proxy_version }}"
+          body_path: /tmp/changelogs/localega-tsd-proxy.md
           prerelease: false
 
   get-new-tag-tsd-api-mock:
@@ -191,8 +210,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'temurin'
+          java-version: "21"
+          distribution: "temurin"
       - name: Bump patch version for tsd-api-mock
         id: bump_tsd_api_mock_version
         run: echo "new_tsd_api_mock_version=${{ needs.get-new-tag-tsd-api-mock.outputs.new_version }}" >> $GITHUB_OUTPUT
@@ -214,19 +233,24 @@ jobs:
         with:
           context: ./services/tsd-api-mock
           push: true
-          no-cache: 'true'
+          no-cache: "true"
           tags: |
             ghcr.io/${{ env.repo_name }}:tsd-api-mock-${{ steps.bump_tsd_api_mock_version.outputs.new_tsd_api_mock_version }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             org.opencontainers.image.revision=${{ github.sha }}
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :services:tsd-api-mock:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "tsd-api-mock-${{ steps.bump_tsd_api_mock_version.outputs.new_tsd_api_mock_version }}"
+          body_path: /tmp/changelogs/tsd-api-mock.md
           prerelease: false
 
   get-new-tag-cega-mock:
@@ -259,19 +283,24 @@ jobs:
         with:
           context: ./services/cega-mock
           push: true
-          no-cache: 'true'
+          no-cache: "true"
           tags: |
             ghcr.io/${{ env.repo_name }}:cega-mock-${{ steps.bump_cega_mock_version.outputs.new_cega_mock_version }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.clone_url }}
             org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
             org.opencontainers.image.revision=${{ github.sha }}
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :services:cega-mock:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "cega-mock-${{ steps.bump_cega_mock_version.outputs.new_cega_mock_version }}"
+          body_path: /tmp/changelogs/cega-mock.md
           prerelease: false
 
   get-new-tag-mq-interceptor:
@@ -304,12 +333,17 @@ jobs:
           docker pull ghcr.io/${{ env.repo_name }}:mq-interceptor-${{ github.event.number }}
           docker tag ghcr.io/${{ env.repo_name }}:mq-interceptor-${{ github.event.number }} ghcr.io/${{ env.repo_name }}:mq-interceptor-${{ steps.bump_mq_interceptor_version.outputs.new_mq_interceptor_version }}
           docker push ghcr.io/${{ env.repo_name }}:mq-interceptor-${{ steps.bump_mq_interceptor_version.outputs.new_mq_interceptor_version }}
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :services:mq-interceptor:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "mq-interceptor-${{ steps.bump_mq_interceptor_version.outputs.new_mq_interceptor_version }}"
+          body_path: /tmp/changelogs/mq-interceptor.md
           prerelease: false
 
   get-new-tag-lega-commander:
@@ -342,18 +376,23 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: '~> v2'
+          version: "~> v2"
           args: release --clean
           workdir: cli/lega-commander
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CGO_ENABLED: "0"
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :cli:lega-commander:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         if: success()
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: "lega-commander-${{ steps.bump_lega_commander_version.outputs.new_lega_commander_version }}"
+          body_path: /tmp/changelogs/lega-commander.md
           prerelease: false
 
   get-new-tag-e2eTests:
@@ -370,11 +409,16 @@ jobs:
       - name: Bump patch version for e2eTests
         id: bump_e2eTests_version
         run: echo "new_e2eTests_version=${{ needs.get-new-tag-e2eTests.outputs.new_version }}" >> $GITHUB_OUTPUT
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :e2eTests:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: e2eTests-${{ steps.bump_e2eTests_version.outputs.new_e2eTests_version }}
+          body_path: /tmp/changelogs/e2eTests.md
           prerelease: false
 
   get-new-tag-fega-norway:
@@ -390,9 +434,14 @@ jobs:
       - name: Bump patch version for FEGA-Norway
         id: bump_fega_norway_version
         run: echo "new_fega_norway_version=${{ needs.get-new-tag-fega-norway.outputs.new_version }}" >> $GITHUB_OUTPUT
+      - name: Generate changelog
+        run: |
+          mkdir -p /tmp/changelogs
+          ./gradlew :FEGA-Norway:generateChangelog --outputDir=/tmp/changelogs
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           tag_name: FEGA-Norway-${{ steps.bump_fega_norway_version.outputs.new_fega_norway_version }}
+          body_path: /tmp/changelogs/FEGA-Norway.md
           prerelease: false

--- a/CHANGELOG-README.md
+++ b/CHANGELOG-README.md
@@ -1,0 +1,156 @@
+# Changelog Generation for FEGA-Norway
+
+This document explains how to use the changelog generation tools built into the Gradle build system.
+
+## Overview
+
+The FEGA-Norway monorepo includes a custom Gradle plugin that can generate changelogs for each component based on git commit history. The changelog will list commits made to the specific component directory, organized by date.
+
+Changelogs are generated during the release process and attached to GitHub releases, rather than being stored in the repository itself.
+
+## Generating Changelogs Locally
+
+### Generate Changelog for a Single Component
+
+To generate a changelog for a specific component locally:
+
+```bash
+./gradlew :component-path:generateChangelog
+```
+
+For example:
+
+```bash
+# Generate changelog for the crypt4gh library
+./gradlew :lib:crypt4gh:generateChangelog
+
+# Generate changelog for the lega-commander CLI
+./gradlew :cli:lega-commander:generateChangelog
+```
+
+### Generate Changelogs for All Components
+
+To generate changelogs for all components at once:
+
+```bash
+./gradlew generateAllChangelogs
+```
+
+By default, this will create or update CHANGELOG.md files in each component's directory for local viewing.
+
+### External Changelog Generation
+
+To generate changelogs to an external directory instead of the component directories:
+
+```bash
+# Generate changelog to a custom directory
+./gradlew :lib:crypt4gh:generateChangelog --outputDir=/path/to/output
+
+# Example: Generate to the /tmp directory
+./gradlew :lib:crypt4gh:generateChangelog --outputDir=/tmp
+```
+
+The generated file will be named after the component (e.g., `crypt4gh.md`).
+
+## Customizing Changelog Generation
+
+The changelog generator supports several options:
+
+### Specifying Version Range
+
+By default, the changelog will include all commits made to a component since its last tag. You can customize this:
+
+```bash
+# Generate changelog since a specific tag
+./gradlew :lib:crypt4gh:generateChangelog --sinceTag=crypt4gh-1.0.0
+
+# Generate changelog between two points
+./gradlew :lib:crypt4gh:generateChangelog --sinceTag=crypt4gh-1.0.0 --toTag=crypt4gh-1.1.0
+```
+
+### Controlling Fallback Behavior
+
+If no commits are found in the specified range (which may happen if the most recent tag is newer than the most recent commit), the system will automatically fall back to including the most recent commits. You can control how many commits to include:
+
+```bash
+# Specify the number of commits to include when falling back
+./gradlew :lib:crypt4gh:generateChangelog --fallbackCommitCount=30
+```
+
+The default fallback count is 20 commits.
+
+## How It Works
+
+The changelog generator:
+
+1. Identifies the component's directory in the monorepo
+2. Uses `git log` to find commits that modified files in that directory
+3. Parses commit messages and formats them with links to GitHub commits
+4. Groups commits by date
+5. Writes the formatted output either to a CHANGELOG.md file in the component's directory or to an external location
+
+## Changelog Format
+
+The generated changelog follows this format:
+
+```markdown
+# Changelog for [component-name]
+
+All notable changes to this component will be documented in this file.
+
+## Version X.Y.Z (YYYY-MM-DD)
+
+### YYYY-MM-DD
+
+- Commit message 1 ([commit-hash](link-to-commit))
+- Commit message 2 ([commit-hash](link-to-commit))
+
+### YYYY-MM-DD
+
+- Commit message 3 ([commit-hash](link-to-commit))
+```
+
+## Integration with CI/CD
+
+In the CI/CD pipeline, changelogs are automatically generated during the release process and attached directly to GitHub releases. This approach:
+
+1. Keeps the repository clean without unnecessary changelog commits
+2. Ensures users have access to changelogs when downloading releases
+3. Integrates with Dependabot to show changes when updating dependencies
+
+The release workflow does this by:
+
+- Generating changelogs to a temporary directory
+- Attaching the generated file as the release description
+
+Example from our release workflow:
+
+```yaml
+- name: Generate changelog
+  run: |
+    mkdir -p /tmp/changelogs
+    ./gradlew :component-path:generateChangelog --outputDir=/tmp/changelogs
+
+- name: Create GitHub release
+  uses: softprops/action-gh-release@v2
+  with:
+    tag_name: "component-name-x.y.z"
+    body_path: /tmp/changelogs/component-name.md
+```
+
+## Best Practices for Commit Messages
+
+To make your changelogs more useful, follow these guidelines for commit messages:
+
+- Use a consistent format: `type: short description`
+- Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+- Keep the first line under 72 characters
+- Use the imperative mood ("Add feature" not "Added feature")
+- Reference issue numbers when applicable: `fix: resolve race condition (#123)`
+
+## Viewing Changelogs
+
+Changelogs for released components can be found:
+
+1. On the GitHub Releases page for each component
+2. In Dependabot PRs when updating dependencies

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,3 +17,17 @@ tasks.test { useJUnitPlatform() }
 tasks.wrapper {
     gradleVersion = "8.10"
 }
+
+// Apply the changelog plugin to all projects
+allprojects {
+    apply(plugin = "no.elixir.fega.changelog")
+}
+
+// Add a task to generate changelogs for all components
+tasks.register("generateAllChangelogs") {
+    group = "documentation"
+    description = "Generates CHANGELOG.md files for all components"
+    
+    // Make the task depend on the generateChangelog tasks of all subprojects
+    dependsOn(subprojects.map { it.tasks.named("generateChangelog") })
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,5 +23,11 @@ gradlePlugin {
             id = "extra-java-module-info"
             implementationClass = "org.gradle.transform.javamodules.ExtraModuleInfoPlugin"
         }
+        
+        // Register our changelog plugin
+        register("changelog") {
+            id = "no.elixir.fega.changelog"
+            implementationClass = "no.elixir.fega.ChangelogPlugin"
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/no/elixir/fega/ChangelogPlugin.kt
+++ b/buildSrc/src/main/kotlin/no/elixir/fega/ChangelogPlugin.kt
@@ -1,0 +1,11 @@
+package no.elixir.fega
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class ChangelogPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        // Register the task
+        project.tasks.register("generateChangelog", GenerateChangelogTask::class.java)
+    }
+} 

--- a/buildSrc/src/main/kotlin/no/elixir/fega/GenerateChangelogTask.kt
+++ b/buildSrc/src/main/kotlin/no/elixir/fega/GenerateChangelogTask.kt
@@ -1,0 +1,193 @@
+package no.elixir.fega
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+import java.io.File
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+abstract class GenerateChangelogTask : DefaultTask() {
+    @get:Input
+    @get:Option(option = "sinceTag", description = "Generate changelog since specified tag (default: latest tag for component)")
+    @get:Optional
+    abstract val sinceTag: Property<String>
+
+    @get:Input
+    @get:Option(option = "toTag", description = "Generate changelog to specified tag (default: HEAD)")
+    @get:Optional
+    abstract val toTag: Property<String>
+
+    @get:Input
+    @get:Option(option = "fallbackCommitCount", description = "Number of commits to include when falling back to recent commits")
+    @get:Optional
+    abstract val fallbackCommitCount: Property<Int>
+
+    @get:Input
+    @get:Optional
+    abstract val outputDir: Property<String>
+
+    init {
+        sinceTag.convention("")
+        toTag.convention("HEAD")
+        fallbackCommitCount.convention(20)
+        outputDir.convention("")
+        description = "Generates a CHANGELOG.md file based on git commits for the component"
+        group = "documentation"
+    }
+
+    @TaskAction
+    fun generateChangelog() {
+        val projectDir = project.projectDir.absolutePath
+        val componentName = project.name
+        val componentPath = project.path.replace(":", "/")
+            .removePrefix("/")
+
+        val fullComponentPath = if (componentPath.isNotEmpty()) {
+            componentPath
+        } else {
+            // Root project case
+            ""
+        }
+
+        logger.lifecycle("Generating changelog for component: $componentName")
+        logger.lifecycle("Component path: $fullComponentPath")
+
+        val targetFile = if (outputDir.get().isNotEmpty()) {
+            File(outputDir.get(), "${project.name}.md")
+        } else {
+            File(project.projectDir, "CHANGELOG.md")
+        }
+        
+        val since = if (sinceTag.get().isEmpty()) {
+            // Find the latest tag for this component
+            val latestTagProcess = ProcessBuilder(
+                "bash", "-c", "git describe --tags --abbrev=0 --match=\"$componentName-*\" 2>/dev/null || echo ''"
+            ).directory(project.rootDir).start()
+            
+            latestTagProcess.waitFor()
+            val latestTag = latestTagProcess.inputStream.bufferedReader().readText().trim()
+            
+            if (latestTag.isEmpty()) {
+                // No tag found, use start of git history
+                ""
+            } else {
+                latestTag
+            }
+        } else {
+            sinceTag.get()
+        }
+
+        val sinceOption = if (since.isEmpty()) "" else "$since.."
+        val toOption = toTag.get()
+        val rangeOption = "$sinceOption$toOption"
+
+        logger.lifecycle("Generating changelog from $rangeOption")
+
+        // Get git log for the component directory
+        val pathOption = if (fullComponentPath.isEmpty()) {
+            ""
+        } else {
+            "-- $fullComponentPath"
+        }
+
+        val gitLogCmd = "git log --pretty=format:'%ad | %s | [%h](https://github.com/ELIXIR-NO/FEGA-Norway/commit/%H)' --date=short $rangeOption $pathOption"
+        
+        logger.lifecycle("Executing: $gitLogCmd")
+        
+        val process = ProcessBuilder(
+            "bash", "-c", gitLogCmd
+        ).directory(project.rootDir).start()
+        
+        process.waitFor()
+        
+        var gitLog = process.inputStream.bufferedReader().readText()
+        val errorLog = process.errorStream.bufferedReader().readText()
+        
+        if (errorLog.isNotEmpty()) {
+            logger.error("Error generating changelog: $errorLog")
+        }
+
+        // If no commits found with the range, fall back to the most recent 20 commits for the component
+        if (gitLog.isBlank()) {
+            logger.lifecycle("No commits found in specified range. Falling back to recent commits.")
+            
+            val fallbackCmd = "git log -n ${fallbackCommitCount.get()} --pretty=format:'%ad | %s | [%h](https://github.com/ELIXIR-NO/FEGA-Norway/commit/%H)' --date=short $pathOption"
+            logger.lifecycle("Executing fallback: $fallbackCmd")
+            
+            val fallbackProcess = ProcessBuilder(
+                "bash", "-c", fallbackCmd
+            ).directory(project.rootDir).start()
+            
+            fallbackProcess.waitFor()
+            gitLog = fallbackProcess.inputStream.bufferedReader().readText()
+        }
+
+        // Group commits by date
+        val commitsByDate = gitLog.split("\n")
+            .filter { it.isNotEmpty() }
+            .groupBy { it.substringBefore(" | ") }
+            .toSortedMap(Comparator.reverseOrder())
+
+        // Generate changelog content
+        val title = "# Changelog for $componentName"
+        val description = "\nAll notable changes to this component will be documented in this file.\n"
+        
+        val currentVersion = getCurrentVersion(project, componentName)
+        val versionHeader = if (currentVersion.isNotEmpty()) {
+            "\n## Version $currentVersion (${LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)})\n"
+        } else {
+            "\n## Unreleased\n"
+        }
+
+        val content = StringBuilder().apply {
+            append(title)
+            append(description)
+            append(versionHeader)
+            
+            if (commitsByDate.isEmpty()) {
+                append("\nNo changes recorded.\n")
+            } else {
+                commitsByDate.forEach { (date, commits) ->
+                    append("\n### $date\n")
+                    commits.forEach { commit ->
+                        val parts = commit.split(" | ", limit = 3)
+                        if (parts.size >= 3) {
+                            val (_, message, hash) = parts
+                            append("- $message ($hash)\n")
+                        }
+                    }
+                }
+            }
+        }
+
+        // Write to CHANGELOG.md
+        targetFile.writeText(content.toString())
+        logger.lifecycle("Changelog generated at ${targetFile.absolutePath}")
+    }
+
+    private fun getCurrentVersion(project: Project, componentName: String): String {
+        // First check if version is set as project property
+        if (project.hasProperty("version") && project.property("version") != "unspecified") {
+            return project.property("version").toString()
+        }
+
+        // Try to get from latest git tag
+        val latestTagProcess = ProcessBuilder(
+            "bash", "-c", "git describe --tags --abbrev=0 --match=\"$componentName-*\" 2>/dev/null || echo ''"
+        ).directory(project.rootDir).start()
+        
+        latestTagProcess.waitFor()
+        val latestTag = latestTagProcess.inputStream.bufferedReader().readText().trim()
+        
+        if (latestTag.isNotEmpty()) {
+            return latestTag.substringAfter("$componentName-")
+        }
+
+        return ""
+    }
+} 


### PR DESCRIPTION
This commit introduces a comprehensive changelog generation system for the monorepo:

- Add GenerateChangelogTask to produce formatted changelogs from git history
- Create ChangelogPlugin to register the task in all projects
- Integrate changelog generation into CI/CD release process
- Generate changelogs externally and attach to GitHub releases
- Add fallback mechanism for components with no recent commits
- Include detailed documentation for developers

The implementation keeps the repository clean by not storing changelogs in the codebase, while ensuring users have access to well-formatted changelogs with each release.