### PR TITLE
pre-merge checks

### DIFF
--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -1,0 +1,65 @@
+name: Build Components
+on:
+  pull_request:
+    paths:
+      - 'lib/crypt4gh/**'
+      - 'lib/clearinghouse/**'
+      - 'cli/lega-commander/**'
+    branches:
+      - main
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      localega-tsd-proxy: ${{ steps.changes.outputs.crypt4gh }}
+      mq-interceptor: ${{ steps.changes.outputs.clearinghouse }}
+      cega-mock: ${{ steps.changes.outputs.lega-commander }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            crypt4gh:
+              - 'lib/crypt4gh/**'
+            clearinghouse:
+              - 'lib/clearinghouse/**'
+            lega-commander:
+              - 'cli/lega-commander/**'
+
+  crypt4gh:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.crypt4gh == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build  crypt4gh
+        run: |
+          ./gradlew :lib:crypt4gh:publish --dry-run
+
+  clearinghouse:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.clearinghouse == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: build clearinghouse
+        run: |
+          ./gradlew :lib:clearinghouse:publish --dry-run
+  lega-commander:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.lega-commander == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.24
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean --snapshot
+          workdir: cli/lega-commander

--- a/.github/workflows/build-components.yml
+++ b/.github/workflows/build-components.yml
@@ -12,9 +12,9 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     outputs:
-      localega-tsd-proxy: ${{ steps.changes.outputs.crypt4gh }}
-      mq-interceptor: ${{ steps.changes.outputs.clearinghouse }}
-      cega-mock: ${{ steps.changes.outputs.lega-commander }}
+      crypt4gh: ${{ steps.changes.outputs.crypt4gh }}
+      clearinghouse: ${{ steps.changes.outputs.clearinghouse }}
+      lega-commander: ${{ steps.changes.outputs.lega-commander }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3


### PR DESCRIPTION
There is already a workflow to check image building pre-merge to guarantee smooth publishing, this pr introduces a new workflow that does the same thing for crypt4gh and clearinghouse and lega-commander.