### PR TITLE
remove redundant build step before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,6 @@ jobs:
         run: echo "new_clearinghouse_version=${{ needs.get-new-tag-clearinghouse.outputs.new_version }}" >> $GITHUB_OUTPUT
       - name: Release clearinghouse
         run: |
-          ./gradlew :lib:clearinghouse:build -Pversion=${{ steps.bump_clearinghouse_version.outputs.new_clearinghouse_version }}
           ./gradlew :lib:clearinghouse:publish -Pversion=${{ steps.bump_clearinghouse_version.outputs.new_clearinghouse_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +96,6 @@ jobs:
         run: echo "new_crypt4gh_version=${{ needs.get-new-tag-crypt4gh.outputs.new_version }}" >> $GITHUB_OUTPUT
       - name: Release crypt4gh
         run: |
-          ./gradlew :lib:crypt4gh:build -Pversion=${{ steps.bump_crypt4gh_version.outputs.new_crypt4gh_version }}
           ./gradlew :lib:crypt4gh:publish -Pversion=${{ steps.bump_crypt4gh_version.outputs.new_crypt4gh_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -129,7 +127,6 @@ jobs:
         run: echo "new_tsd_file_api_client_version=${{ needs.get-new-tag-tsd-file-api-client.outputs.new_version }}" >> $GITHUB_OUTPUT
       - name: Release tsd-file-api-client
         run: |
-          ./gradlew :lib:tsd-file-api-client:build -Pversion=${{ steps.bump_tsd_file_api_client_version.outputs.new_tsd_file_api_client_version }}
           ./gradlew :lib:tsd-file-api-client:publish -Pversion=${{ steps.bump_tsd_file_api_client_version.outputs.new_tsd_file_api_client_version }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
to remove the build command sright before publish commands for jar artifacts which is useless in releasing packages.