### PR TITLE
Feat/resume upload folder

### DIFF
--- a/cli/lega-commander/streaming/streaming.go
+++ b/cli/lega-commander/streaming/streaming.go
@@ -193,7 +193,7 @@ func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *s
                 return fmt.Errorf(
                     "File %s is already in the inbox.\n"+
                         "If you want to replace it, remove it first using:\n"+
-                        "  lega-commander files -d %s",
+                        "  lega-commander inbox -d %s",
                     file.Name(),
                     filepath.Base(uploadedFile.FileName),
                 )

--- a/cli/lega-commander/streaming/streaming.go
+++ b/cli/lega-commander/streaming/streaming.go
@@ -155,19 +155,17 @@ func (s defaultStreamer) uploadFolder(folder *os.File, resume, straight bool) er
 
         err = s.Upload(entryPath, resume, straight)
         if err != nil {
-            if errMsg := err.Error();
-               containsIgnoreCase(errMsg, "is already uploaded.") {
-                warnings = append(
-                    warnings,
-                    fmt.Sprintf("Skipped %s: already in the inbox", entry.Name()),
-                )
+            errMsg := err.Error()
+            if strings.Contains(errMsg, "is already in the inbox") {
+                warnings = append(warnings,
+                    fmt.Sprintf("Skipped %s: already in the inbox", entry.Name()))
                 continue
             }
             return err
         }
     }
     if len(warnings) > 0 {
-        fmt.Println(aurora.Yellow("WARNING: Some files in the folder were skipped:"))
+        fmt.Println(aurora.Yellow("WARNING: Some files were skipped:"))
         for _, w := range warnings {
             fmt.Println(aurora.Yellow("  - " + w))
         }


### PR DESCRIPTION
**Folder uploads:**

- Already uploaded files are skipped instead of causing the entire upload to halt.  
- A summary of skipped files is printed at the end, using yellow warnings

**Single-file uploads** logic remain unchanged: if the file is already uploaded, the command exits. The error message shown (when the file already exists in the inbox) has been updated to be more "comprehensive".

**Resume behavior (-r)** is also unchanged thus partial uploads will be resumed, and fully uploaded files will still be skipped with a summary warning.

Fixes #46 