### PR TITLE
docs(crypt4gh): Add more metadata to pom.xml file

### DIFF
--- a/lib/crypt4gh/build.gradle.kts
+++ b/lib/crypt4gh/build.gradle.kts
@@ -28,6 +28,7 @@ tasks.test {
     useJUnitPlatform()
 }
 
+// Note: the project version should be set with the argument "-Pversion=<version>" when building
 tasks.jar {
     manifest {
         attributes(
@@ -47,12 +48,50 @@ publishing {
                 name.set("Crypt4GH")
                 description.set("Crypt4GH standard implementation")
                 url.set("https://github.com/ELIXIR-NO/FEGA-Norway/tree/main/lib/crypt4gh")
+                licenses {
+                    license {
+                        name.set("MIT License")
+                        url.set("https://opensource.org/license/MIT")
+                        distribution.set("repo")
+                    }
+                }
                 scm {
+                    connection.set("scm:git:git://github.com/ELIXIR-NO/FEGA-Norway.git")
+                    developerConnection.set("scm:git:ssh://github.com:ELIXIR-NO/FEGA-Norway.git")
                     url.set("https://github.com/ELIXIR-NO/FEGA-Norway")
                 }
                 issueManagement {
                     system.set("GitHub")
                     url.set("https://github.com/ELIXIR-NO/FEGA-Norway/issues")
+                }
+                // Add <developers> block with roles to pom.xml
+                withXml {
+                    val root = asNode()
+
+                    // Remove any existing <developers> section just in case
+                    root.children().removeIf { (it as? groovy.util.Node)?.name() == "developers" }
+
+                    // Create <developers>
+                    val developers = root.appendNode("developers")
+
+                    /**
+                     * @param id
+                     * @param name
+                     * @param roles
+                     */
+                    fun addDeveloper(id: String, name: String, roles: List<String>) {
+                        val dev = developers.appendNode("developer")
+                        dev.appendNode("id", id)
+                        dev.appendNode("name", name)
+                        val rolesNode = dev.appendNode("roles")
+                        roles.forEach { rolesNode.appendNode("role", it) }
+                    }
+
+                    addDeveloper("dtitov", "Dmytro Titov", listOf("Lead Developer"))
+                    addDeveloper("kjetilkl", "Kjetil Klepper", listOf("Developer", "Maintainer"))
+                    addDeveloper("a-ghanem", "Ahmed Ghanem", listOf("Maintainer"))
+                    addDeveloper("lyytinen", "Jussi Lyytinen", listOf("Contributor"))
+                    addDeveloper("brainstorm", "Roman Valls Guimera", listOf("Contributor"))
                 }
             }
         }

--- a/lib/crypt4gh/build.gradle.kts
+++ b/lib/crypt4gh/build.gradle.kts
@@ -48,6 +48,10 @@ publishing {
                 name.set("Crypt4GH")
                 description.set("Crypt4GH standard implementation")
                 url.set("https://github.com/ELIXIR-NO/FEGA-Norway/tree/main/lib/crypt4gh")
+                organization {
+                    name.set("Elixir Norway")
+                    url.set("https://elixir.no")
+                }
                 licenses {
                     license {
                         name.set("MIT License")
@@ -87,7 +91,7 @@ publishing {
                         roles.forEach { rolesNode.appendNode("role", it) }
                     }
 
-                    addDeveloper("dtitov", "Dmytro Titov", listOf("Lead Developer"))
+                    addDeveloper("dtitov", "Dmytro Titov", listOf("Lead Developer (emeritus)"))
                     addDeveloper("kjetilkl", "Kjetil Klepper", listOf("Developer", "Maintainer"))
                     addDeveloper("a-ghanem", "Ahmed Ghanem", listOf("Maintainer"))
                     addDeveloper("lyytinen", "Jussi Lyytinen", listOf("Contributor"))


### PR DESCRIPTION
Add information about the license (MIT), organization (Elixir Norway), developers and SCM to the `pom.xml` file that is generated from the Gradle build file. This meta-data is [required](https://central.sonatype.org/publish/requirements/#required-pom-metadata) for publishing to Maven Central.

The `<developers>` are added in a programmatic way in order to include information about their _roles_, which is apparently not supported directly with regular Gradle syntax.