### PR TITLE
Update update sda-doa version in docker compose template

### DIFF
--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -435,7 +435,7 @@ services:
   doa:
     container_name: doa
     hostname: doa
-    image: ghcr.io/neicnordic/sda-doa:v1.6.175
+    image: ghcr.io/neicnordic/sda-doa:v1.6.186
     depends_on:
       file-orchestrator:
         condition: service_healthy


### PR DESCRIPTION
The sda-doa version 1.6.175 is no longer present in the in the github container registery and causes the docker pull command to fail. This has a cascading effect on the e2etest. This quick fix simply calls a slightly updated version of sda-doa which is still available in the registry.