### PR TITLE
add setup-java step 

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -146,6 +146,10 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
       - name: Build with Gradle
         run: ./gradlew services:tsd-api-mock:assemble
       - name: Set Repository Name


### PR DESCRIPTION
when tsd-api-mock image is being built it needs to use java 21 (the default in the runner in the workflow is 17).