### PR TITLE
chore(conventions): remove unused dependency

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,7 +13,6 @@ dependencies {
     implementation("org.ow2.asm:asm:9.8")
     implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.0")
     implementation("io.spring.gradle:dependency-management-plugin:1.1.7")
-    implementation("org.hibernate.orm:hibernate-gradle-plugin:7.0.0.Final")
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/kotlin/springboot-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/springboot-conventions.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     java
     id("org.springframework.boot")
     id("io.spring.dependency-management")
-    id("org.hibernate.orm")
     id("formatting-conventions")
 }
 
@@ -30,12 +29,7 @@ dependencies {
 
 tasks.withType<Test> { useJUnitPlatform() }
 
-hibernate {
-    enhancement {
-        enableAssociationManagement.set(true)
-    }
-}
-
 tasks.getByName<Jar>("jar") {
     enabled = false
 }
+


### PR DESCRIPTION
This depedency was added originally under the assumption that it would be used in almost all springboot application. Removing this now as this isn't used in either of the 2 springboot services we currently have.