### PR TITLE
remove pull request trigger in build and test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,8 +2,6 @@ name: Build and test
 
 on:
   push:
-  pull_request:
-    branches: [main]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Trigger on push covers our need. Triggers on pr just run the same workflow twice.