### PR TITLE
add check-commit-message.yml workflow as a precheck for merging prs

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,0 +1,57 @@
+name: Check Commit Messages
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - main
+
+env:
+  BUMPS: "major minor patch"
+  COMPONENTS: "lega-commander e2eTests clearinghouse crypt4gh tsd-file-api-client cega-mock localega-tsd-proxy mq-interceptor tsd-api-mock FEGA-Norway"
+
+jobs:
+  check-commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find commit messages with bumps
+        id: check-commit-messages
+        run: |
+          bumps=($BUMPS)
+          bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
+          all_matches=$(git log origin/"${{ github.event.pull_request.base.ref }}"..origin/"${{ github.head_ref }}" --pretty=format:"%s" | grep -E "#(${bumps_pattern})_" || true)
+          {
+          echo "all_matches<<EOF"
+          echo "$all_matches"
+          echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Check typo in component names
+        id: check-typos
+        if: steps.check-commit-messages.outputs.all_matches != ''
+        run: |
+          components=($COMPONENTS)
+          bumps=($BUMPS)
+          bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
+          components_pattern=$(IFS='|'; echo "${components[*]}")
+          pattern="#(${bumps_pattern})_(${components_pattern})([^a-zA-Z0-9_]|$)"
+          wrong_matches=$(echo "${{ steps.check-commit-messages.outputs.all_matches }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -Ev "$pattern" || true)
+          {
+          echo "wrong_matches<<EOF"
+          echo "$wrong_matches"
+          echo "EOF"
+          } >> $GITHUB_OUTPUT
+
+      - name: Fail if typos found
+        if: steps.check-typos.outputs.wrong_matches != ''
+        run: |
+          echo "Typos found in commit messages:"
+          echo "${{ steps.check-typos.outputs.wrong_matches }}"
+          exit 1

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -27,29 +27,29 @@ jobs:
       - name: Find commit messages with bumps
         id: check-commit-messages
         run: |
-          read -a bumps <<< "$BUMPS"
+          read -r -a bumps <<< "$BUMPS"
           bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
           all_matches=$(git log origin/"$BASE_REF"..origin/"$HEAD_REF" --pretty=format:"%s" | grep -E "#(${bumps_pattern})_" || true)
           {
-          echo "all_matches<<EOF"
-          echo "$all_matches"
-          echo "EOF"
+            echo "all_matches<<EOF"
+            echo "$all_matches"
+            echo "EOF"
           } >> $GITHUB_OUTPUT
 
       - name: Check typo in component names
         id: check-typos
         if: steps.check-commit-messages.outputs.all_matches != ''
         run: |
-          read -a components <<< "$COMPONENTS"
-          read -a bumps <<< "$BUMPS"
+          read -r -a components <<< "$COMPONENTS"
+          read -r -a bumps <<< "$BUMPS"
           bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
           components_pattern=$(IFS='|'; echo "${components[*]}")
           pattern="#(${bumps_pattern})_(${components_pattern})([^a-zA-Z0-9_]|$)"
           wrong_matches=$(echo "${{ steps.check-commit-messages.outputs.all_matches }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -Ev "$pattern" || true)
           {
-          echo "wrong_matches<<EOF"
-          echo "$wrong_matches"
-          echo "EOF"
+            echo "wrong_matches<<EOF"
+            echo "$wrong_matches"
+            echo "EOF"
           } >> $GITHUB_OUTPUT
 
       - name: Fail if typos found

--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -15,6 +15,9 @@ env:
 jobs:
   check-commit-message:
     runs-on: ubuntu-latest
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_REF: ${{ github.head_ref }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -24,9 +27,9 @@ jobs:
       - name: Find commit messages with bumps
         id: check-commit-messages
         run: |
-          bumps=($BUMPS)
+          read -a bumps <<< "$BUMPS"
           bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
-          all_matches=$(git log origin/"${{ github.event.pull_request.base.ref }}"..origin/"${{ github.head_ref }}" --pretty=format:"%s" | grep -E "#(${bumps_pattern})_" || true)
+          all_matches=$(git log origin/"$BASE_REF"..origin/"$HEAD_REF" --pretty=format:"%s" | grep -E "#(${bumps_pattern})_" || true)
           {
           echo "all_matches<<EOF"
           echo "$all_matches"
@@ -37,8 +40,8 @@ jobs:
         id: check-typos
         if: steps.check-commit-messages.outputs.all_matches != ''
         run: |
-          components=($COMPONENTS)
-          bumps=($BUMPS)
+          read -a components <<< "$COMPONENTS"
+          read -a bumps <<< "$BUMPS"
           bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
           components_pattern=$(IFS='|'; echo "${components[*]}")
           pattern="#(${bumps_pattern})_(${components_pattern})([^a-zA-Z0-9_]|$)"


### PR DESCRIPTION
This workflow first tries to find #minor_ #major_ #patch_ in all the commits and if it finds them then it checks if the rest of the word matches with component names, and in case it does not match it fails.