### PR TITLE
WARNING: AI GENERATED. Potential fix for code scanning alert no. 80: Unsafe certificate trust

### DIFF
--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/config/RabbitMQConfig.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/config/RabbitMQConfig.java
@@ -52,9 +52,11 @@ public class RabbitMQConfig {
       if (props.getTruststore() != null && !props.getTruststore().isEmpty()) {
         // Configure SSL on the underlying factory
         rabbitConnectionFactory.useSslProtocol(createSslContext(props));
+        rabbitConnectionFactory.enableHostnameVerification();
       } else {
         // Use the defaults
         rabbitConnectionFactory.useSslProtocol();
+        rabbitConnectionFactory.enableHostnameVerification();
       }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/80](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/80)

To fix the issue, hostname verification must be explicitly enabled for the RabbitMQ connection factory. This can be achieved by calling the `enableHostnameVerification` method on the `com.rabbitmq.client.ConnectionFactory` instance (`rabbitConnectionFactory`). This ensures that the hostname in the server's certificate matches the hostname of the server being connected to, mitigating the risk of man-in-the-middle attacks.

**Steps to implement the fix:**
1. Add a call to `rabbitConnectionFactory.enableHostnameVerification()` after configuring SSL using `useSslProtocol`.
2. Ensure this change is applied in both cases: when a custom trust store is used and when the default SSL configuration is applied.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
