### PR TITLE
Specify full golang base image to support Podman builds

### DIFF
--- a/services/mq-interceptor/Dockerfile
+++ b/services/mq-interceptor/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM docker.io/library/golang:1.24 AS builder
 
 ENV GOPATH=$PWD
 ENV CGO_ENABLED=0


### PR DESCRIPTION
 I get this when building with podman:

`Error: creating build container: short-name resolution enforced but cannot prompt without a TTY`

Using the full image reference ensures compatibility 