### PR TITLE
Fix goreleaser warnings

### DIFF
--- a/cli/lega-commander/.goreleaser.yml
+++ b/cli/lega-commander/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 release:
     github:
         owner: ELIXIR-NO
@@ -27,10 +28,10 @@ archives:
           {{- else if eq .Arch "386" }}i386
           {{- else }}{{ .Arch }}{{ end }}
           {{- if .Arm }}v{{ .Arm }}{{ end -}}
-      format: tar.gz
+      formats: [tar.gz]
       format_overrides:
         - goos: windows
-          format: zip
+          formats: [zip]
 
 
 changelog:


### PR DESCRIPTION
add version to goreleaser
replace deprecated options with the new ones