### PR TITLE
Potential fix for code scanning alert no. 87: Uncontrolled data in arithmetic expression

### DIFF
--- a/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/pojo/key/kdf/Bcrypt.java
+++ b/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/pojo/key/kdf/Bcrypt.java
@@ -621,6 +621,9 @@ public final class Bcrypt {
 
     for (int count = 1; count <= blocks; count++) {
       // append 4-byte block counter to the end of the salt
+      if (salt.length > Integer.MAX_VALUE - 4) {
+        throw new IllegalArgumentException("Salt length is too large and may cause an overflow.");
+      }
       byte[] blockSalt = new byte[salt.length + 4];
       System.arraycopy(salt, 0, blockSalt, 0, salt.length);
       blockSalt[blockSalt.length - 4] = (byte) ((count >> 24) & 0xff);


### PR DESCRIPTION
Potential fix for [https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/87](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/87)

To fix the issue, we should validate the length of `salt` before performing arithmetic operations on it. Specifically, we can check if `salt.length` is within a safe range such that `salt.length + 4` will not overflow. If the length exceeds a reasonable threshold, we can throw an exception or handle the error gracefully. Additionally, we can enforce a maximum allowed size for `salt` to ensure that it conforms to expected cryptographic standards.

Changes will be applied to the `bcrypt_pbkdf` method in the `Bcrypt` class.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
