### PR TITLE
fix: remove push from events that triggers pre-check workflow

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -1,6 +1,5 @@
 name: Release Pre Check
 on:
-  push:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Running pre-check workflow on push is unneccesary. this pr removes push event.