### PR TITLE
ci: remove continue-on-error from matrix job

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         component: ${{ fromJson(needs.detect.outputs.changed-components).component }}
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR removes continue-on-error from the matrix job in our release workflow, ensuring that any failing matrix run will cause the entire job to fail.