### PR TITLE
fix: grant required permissions to fix dependabot workflow auth error

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -11,6 +11,9 @@ jobs:
   check_publish:
     needs: detect
     runs-on: ubuntu-latest
+    permissions:
+        contents: read
+        packages: write
     strategy:
       matrix:
         component: ${{ fromJson(needs.detect.outputs.changed-components).component }}


### PR DESCRIPTION
Recently when Dependabot creates a pr and runs the precheck workflow it fails with auth error. This pr fixes it.