### PR TITLE
Prevent dev.sh crash with no args under set -u in mac

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -629,7 +629,7 @@ function show_menu() {
 
 # Main execution logic
 
-if [ -z "$1" ]; then
+if [ -z "${1-}" ]; then
     show_menu
 else
     FUNC_NAME=$1


### PR DESCRIPTION
I found that the script stopped with an error when started with no arguments on macOS