### PR TITLE
remove unused credential in jreleaser

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -56,8 +56,6 @@ jobs:
         uses: jreleaser/release-action@v2
         env:
           JRELEASER_PROJECT_VERSION: 1.0.0-DRYRUN
-          JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USER }}
-          JRELEASER_MAVENCENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
         with:
           arguments: deploy --dry-run -c lib/${{matrix.component}}/jreleaser.yml
 


### PR DESCRIPTION
In dry run Jreleaser does not use credentials (it does not test for authentication) so for precheck these credentials are useless.
On the other hand, when dependabot makes a pr, it does not have access to secrets and the values of these two env are empty which causes an error.