### PR TITLE
[feat]: show the available bump part and component in commit message

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,10 +1,6 @@
 name: Check Commit Messages
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
     branches:
       - main
 
@@ -29,32 +25,45 @@ jobs:
         run: |
           read -r -a bumps <<< "$BUMPS"
           bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
-          all_matches=$(git log origin/"$BASE_REF"..origin/"$HEAD_REF" --pretty=format:"%s" | grep -E "#(${bumps_pattern})_" || true)
+          all_matches=$(git log origin/"$BASE_REF"..origin/"$HEAD_REF" --pretty=format:"%s" | grep -oE "#(${bumps_pattern})_[^ ]*" || true)
           {
             echo "all_matches<<EOF"
             echo "$all_matches"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
-      - name: Check typo in component names
-        id: check-typos
+      - name: Check matches in component names
+        id: check-match
         if: steps.check-commit-messages.outputs.all_matches != ''
         run: |
+          echo "${{ steps.check-commit-messages.outputs.all_matches }}"
           read -r -a components <<< "$COMPONENTS"
           read -r -a bumps <<< "$BUMPS"
           bumps_pattern=$(IFS='|'; echo "${bumps[*]}")
           components_pattern=$(IFS='|'; echo "${components[*]}")
           pattern="#(${bumps_pattern})_(${components_pattern})$"
-          wrong_matches=$(echo "${{ steps.check-commit-messages.outputs.all_matches }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -Ev "$pattern" || true)
+          all=$(echo "${{ steps.check-commit-messages.outputs.all_matches }}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          wrong=$(echo "$all" | grep -Ev "$pattern" || true)
+          valid=$(echo "$all" | grep -E "$pattern" || true)
+
           {
             echo "wrong_matches<<EOF"
-            echo "$wrong_matches"
+            echo "$wrong"
+            echo "EOF"
+            echo "valid_matches<<EOF"
+            echo "$valid"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
+      - name: Available matches
+        if: steps.check-match.outputs.valid_matches != ''
+        run: |
+          echo "Valid commit messages found:"
+          echo "${{ steps.check-match.outputs.valid_matches }}"
+
       - name: Fail if typos found
-        if: steps.check-typos.outputs.wrong_matches != ''
+        if: steps.check-match.outputs.wrong_matches != ''
         run: |
           echo "Typos found in commit messages:"
-          echo "${{ steps.check-typos.outputs.wrong_matches }}"
+          echo "${{ steps.check-match.outputs.wrong_matches }}"
           exit 1


### PR DESCRIPTION
When we put #part_componentName in commit message check-commit-message fails when the component name is wrong, I added a step that shows the correct matches also.