### PR TITLE
fix(crypt4gh): improve key pair generation

### DIFF
--- a/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/app/ConsoleUtils.java
+++ b/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/app/ConsoleUtils.java
@@ -1,6 +1,7 @@
 package no.elixir.crypt4gh.app;
 
 import java.io.Console;
+import java.util.Arrays;
 
 /** Console utility class, not a public API. */
 class ConsoleUtils {
@@ -41,20 +42,32 @@ class ConsoleUtils {
   }
 
   /**
-   * Prompts the user to enter a password on the command-line. The prompt will be repeated if the
-   * length of the provided password is shorter than a specified minimum.
+   * Reads a new password from a parameter or the console. If the password provided as a parameter
+   * is non-empty and valid, it will be returned. If not, the user will be prompted to enter a new
+   * password in the console. The prompt will be repeated if the length of the provided password is
+   * shorter than a specified minimum. After a valid password has been entered, the user must repeat
+   * it to guard against accidental typos.
    *
-   * @param prompt a message to display to the user
+   * @param password A chosen password (can be null)
+   * @param prompt a message to display to the user if a new password must be entered in the console
    * @param minLength a required minimum length for the password
-   * @return A character array containing the password read from the console
+   * @return A character array containing the new password
+   * @throws IllegalArgumentException if no valid password could be returned
    */
-  char[] readPassword(String prompt, int minLength) {
+  char[] readNewPassword(String password, String prompt, int minLength)
+      throws IllegalArgumentException {
+    if (password != null) {
+      if (password.length() >= minLength) return password.toCharArray();
+      else System.out.println("Password is too short: minimum length is " + minLength);
+    }
     while (true) {
-      char[] password = System.console().readPassword(prompt);
-      if (password.length >= minLength) {
-        return password;
+      char[] newPassword = System.console().readPassword(prompt);
+      if (newPassword.length >= minLength) {
+        char[] confirmPassword = System.console().readPassword("Confirm password: ");
+        if (Arrays.equals(newPassword, confirmPassword)) return newPassword;
+        else throw new IllegalArgumentException("Passwords are not identical!");
       } else {
-        System.out.println("Passphrase is too short: min length is " + minLength);
+        System.out.println("Password is too short: minimum length is " + minLength);
       }
     }
   }

--- a/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/app/Main.java
+++ b/lib/crypt4gh/src/main/java/no/elixir/crypt4gh/app/Main.java
@@ -1,5 +1,6 @@
 package no.elixir.crypt4gh.app;
 
+import no.elixir.crypt4gh.pojo.key.Format;
 import org.apache.commons.cli.*;
 
 /** Console application for encrypting/decrypting files. */
@@ -83,10 +84,15 @@ public class Main {
       } else if (line.hasOption(VERSION)) {
         printVersion();
       } else if (line.hasOption(GENERATE)) {
+        String keyformat = line.getOptionValue(KEY_FORMAT, Format.OPENSSL.name());
+        try {
+          Format.valueOf(keyformat.toUpperCase());
+        } catch (IllegalArgumentException e) {
+          System.err.println("Key format must either OpenSSL (default) or Crypt4GH");
+          return;
+        }
         crypt4GHUtils.generateX25519KeyPair(
-            line.getOptionValue(GENERATE),
-            line.getOptionValue(KEY_FORMAT),
-            line.getOptionValue(KEY_PASSWORD));
+            line.getOptionValue(GENERATE), keyformat, line.getOptionValue(KEY_PASSWORD));
       } else {
         if (line.hasOption(ENCRYPT)) {
           if (!line.hasOption(PUBLIC_KEY)) {


### PR DESCRIPTION
If a user generates a new key pair with Crypt4GH, but key files with the chosen name already exist, the old code will ask separately if they want to replace the public and private key files. This means that it is possible to answer YES to one and NO to the other, which results in only one of the key files being updated, and the coupling between the public and private key is lost. This update will only ask once if they want to replace both key files.

Also, Crypt4GH will now complain if the user specifies an unknown (and hence possibly mistyped) "key format" (e.g. "-kf cryp4gh") rather than just defaulting to OpenSSL in such cases. Valid options are "OpenSSL" and "Crypt4GH" (case-insensitive).

Finally, when selecting a password for a newly created private key, the user must re-enter the same password a second time to guard against accidental mistakes in the first password. 