### PR TITLE
fix: pin postgres to 18 and fix `PGDATA` volume structure

### DIFF
--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -154,7 +154,7 @@ services:
   postgres:
     container_name: postgres
     hostname: postgres
-    image: postgres
+    image: postgres:18
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -163,7 +163,7 @@ services:
       - POSTGRES_PASSWORD=<<POSTGRES_POSTGRES_PASSWORD>>
       - POSTGRES_DB=<<POSTGRES_POSTGRES_DB>>
     volumes:
-      - postgres-data:/var/lib/postgresql/data/
+      - postgres-data:/var/lib/postgresql/
       - postgres-confs:/docker-entrypoint-initdb.d/
 
   # SDA


### PR DESCRIPTION
Turns out we weren't pinning the Postgres version in our docker-compose file - we just had `image: postgres` which pulls `latest`. Postgres 18 ([release notes](https://www.postgresql.org/docs/release/18.0/)) with breaking changes to how it stores data - they switched from `/var/lib/postgresql/data/` to version-specific directories like `/var/lib/postgresql/18/data/` to better support upgrades ([see PR #1259](https://github.com/docker-library/postgres/pull/1259)). 

What's strange is that GitHub Actions didn't catch this issue earlier, even though Postgres 18 has been out since September 2025. It only started failing today for us. In our local Docker still had the old version cached, which is why it worked fine for us locally. Our volume mount conflicted with the new structure and Postgres refused to start.

**Fix:** adapted the setup to work with Postgres 18's new structure by changing the volume mount point and pin the version.