### PR TITLE
remove continue-on-error flag and add fail-fast: false 

### DIFF
--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         component: ${{ fromJson(needs.detect.outputs.changed-components).component }}
-    continue-on-error: true
+      fail-fast: false
     steps:
       - uses: actions/checkout@v5
         with:
@@ -81,7 +81,6 @@ jobs:
 
       - name: Run JReleaser
         if: ${{ matrix.component == 'crypt4gh' || matrix.component == 'clearinghouse'}}
-        continue-on-error: true
         uses: jreleaser/release-action@v2
         env:
           JRELEASER_PROJECT_VERSION: ${{ steps.new-tag.outputs.version }}


### PR DESCRIPTION
1. for the matrix fail-fast: false is added to let the parallel publish continue if one of them fails.
2. for jreleaser step. it was added before we add always() to Print log step and later when the logic changed this part wasn’t updated accordingly.