### PR TITLE
Potential fix for code scanning alert no. 202: Executing a command with a relative path

### DIFF
--- a/buildSrc/src/main/kotlin/changelog.gradle.kts
+++ b/buildSrc/src/main/kotlin/changelog.gradle.kts
@@ -12,7 +12,7 @@ tasks.register("generateChangelog") {
         // 2. Get latest tag for this module
         val tagPattern = "$moduleName-*"
         val tagProcess = ProcessBuilder(
-            "bash", "-c", "git tag --list '$tagPattern' --sort=-creatordate | head -n 1"
+            "/bin/bash", "-c", "git tag --list '$tagPattern' --sort=-creatordate | head -n 1"
         )
             .directory(project.rootDir)
             .redirectErrorStream(true)


### PR DESCRIPTION
Potential fix for [https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/202](https://github.com/ELIXIR-NO/FEGA-Norway/security/code-scanning/202)

To eliminate the risk, change the `"bash"` argument in the ProcessBuilder call to its absolute path. This is usually `/bin/bash`, but on some systems it can be `/usr/bin/bash`—since we're only given the code, use `/bin/bash`, which covers the vast majority of use cases. If you know `bash` might be elsewhere, or want configuration flexibility, a further fix could be provided, but the simplest robust fix is to hardcode it. Only modify line 15 inside buildSrc/src/main/kotlin/changelog.gradle.kts, changing `"bash"` to `"/bin/bash"`.

No imports are necessary, as absolute path replacement only changes a literal string. No further followups required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
