### PR TITLE
fix: apply 0-based page indexing and per_page to the max by default

### DIFF
--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
@@ -127,8 +127,8 @@ public class ProxyController {
   public ResponseEntity<?> getFiles(
       @RequestHeader(HttpHeaders.PROXY_AUTHORIZATION) String bearerAuthorization,
       @RequestParam(value = "inbox", defaultValue = "true") boolean inbox,
-      @RequestParam(value = "page", defaultValue = "1") int page,
-      @RequestParam(value = "per_page", defaultValue = "100") int perPage)
+      @RequestParam(value = "page", defaultValue = "0") int page,
+      @RequestParam(value = "per_page", defaultValue = "50000") int perPage)
       throws IOException {
 
     Token token =


### PR DESCRIPTION
TLDR: [See Specification](https://github.com/unioslo/tsd-file-api/blob/a14078969495c5c1abb023571e31b793dc3b4f57/tsdfileapi/api.py#L1645-L1826)