### PR TITLE
fix(mq-interceptor): copy system cert pool to final stage

### DIFF
--- a/services/mq-interceptor/Dockerfile
+++ b/services/mq-interceptor/Dockerfile
@@ -14,6 +14,7 @@ FROM gcr.io/distroless/static:nonroot
 
 COPY --from=builder /app/mq-interceptor /
 COPY --from=builder /app/passwd /etc/passwd
+COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
 
 USER 65534
 


### PR DESCRIPTION
If an explicit setting is required, use `SSL_CERT_DIR=/etc/ssl/certs/`.