### PR TITLE
refactor(localega-tsd-proxy): `PublishMQAspect` inbox path

### DIFF
--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
@@ -34,7 +34,7 @@ public class PublishMQAspect {
   @Value("${tsd.project}")
   private String tsdProjectId;
 
-  @Value("${tsd.inbox-location}")
+  @Value("${tsd.inbox-path-format}")
   private String inboxPathFormat;
 
   @Value("${mq.tsd.exchange}")
@@ -129,6 +129,14 @@ public class PublishMQAspect {
     publishMessage(fileDescriptor, Operation.REMOVE.name().toLowerCase());
   }
 
+  /**
+   * Builds the user-specific relative inbox path by formatting the inbox path format string with
+   * the TSD project ID and the Elixir user ID, then appending the filename. The resulting path
+   * follows the pattern: {@code /<tsd-project-id>-<elixir-user-id>/files/<fileName>}.
+   *
+   * @param fileName the name of the file to append to the inbox path.
+   * @return the fully constructed inbox path for the given file.
+   */
   private String buildInboxPath(String fileName) {
     return String.format(inboxPathFormat, tsdProjectId, request.getAttribute(ELIXIR_ID).toString())
         + fileName;

--- a/services/localega-tsd-proxy/src/main/resources/application.yaml
+++ b/services/localega-tsd-proxy/src/main/resources/application.yaml
@@ -77,7 +77,8 @@ tsd:
   app-id: ${TSD_APP_ID:ega}
   app-out-id: ${TSD_APP_OUT_ID:egaout}
   access-key: ${TSD_ACCESS_KEY}
-  inbox-location: ${TSD_INBOX_LOCATION:/%s-%s/files/}
+  # Format: /<tsd-project-id>-<elixir-user-id>/files/ — the trailing slash is required because the filename is appended at the end.
+  inbox-path-format: ${TSD_INBOX_PATH_FORMAT:/%s-%s/files/}
   root-ca: ${TSD_ROOT_CERT_PATH:/etc/ega/ssl/CA.cert}
   root-ca-password: ${TSD_ROOT_CERT_PASSWORD:}
 


### PR DESCRIPTION
### Refactor PublishMQAspect variable names and comments 

### Context

Variable names and a comment in `PublishMQAspect.java` suggest the code builds a full absolute TSD filesystem path (e.g. `/tsd/pXXX/data/durable/apps/ega/pXXX-elixir-id/files/filename`), when in reality it builds a user-specific relative inbox
path (`/pXXX-elixir-id/files/filename`). The behavior is correct — only the naming/comments are misleading.

### Changes in this PR

1. Rename `tsdInboxLocation` → `inboxPathFormat`

- Line 37-38: field declaration (keep `@Value("${tsd.inbox-location}")` unchanged — only the Java variable name changes)
- Lines 87, 130: both usages in `String.format(...)` calls

2. Fix misleading comment

- Line 88: `// absolute path to the file` → `// user-specific relative inbox path`

3. Extract duplicated path construction into a helper method

The same` String.format(...)` + `fileName` concatenation appears in both `publishUpload` (line 86-88) and `publishRemove` (line 129-131). Extract to a private method like:

```
private String buildInboxPath(String fileName) {
    return String.format(inboxPathFormat, tsdProjectId, request.getAttribute(ELIXIR_ID).toString())
        + fileName;
}
```
Then both call sites simplify to ` fileDescriptor.setFilePath(buildInboxPath(fileName))`.

### What stays the same?

- `tsdProjectId` — accurately describes the value (it IS the TSD project ID)
- Config key `tsd.inbox-location` and env var `TSD_INBOX_LOCATION` — renaming these would be a breaking deployment change
- `exchange`, `routingKey` — standard AMQP terminology, no issue

Closes #102 