### PR TITLE
Enable all-modules pattern for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    all-modules:
+    groups:
+      all-modules:
         patterns:
           - "*"
     schedule:
@@ -38,7 +39,7 @@ updates:
       prefix: "[Java]"
     open-pull-requests-limit: 1
 
-    # Docker Java
+  # Docker Java
   - package-ecosystem: docker
     directories:
       - /e2eTests


### PR DESCRIPTION
Add support for all modules in Dependabot configuration to group updates