### PR TITLE
Add optional --no-duplicate-check flag for uploads

### DIFF
--- a/cli/lega-commander/main.go
+++ b/cli/lega-commander/main.go
@@ -32,22 +32,22 @@ const (
 )
 
 var inboxOptions struct {
-	List   bool   `short:"l" long:"list" description:"Lists uploaded files"`
-	Delete string `short:"d" long:"delete" description:"Deletes uploaded file by name"`
-	PerPage  int    `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
+	List    bool   `short:"l" long:"list" description:"Lists uploaded files"`
+	Delete  string `short:"d" long:"delete" description:"Deletes uploaded file by name"`
+	PerPage int    `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
 	// Pagination note: --page is user-facing and 1-based (page=1 is the first page).
-    // Internally we convert to 0-based before calling the proxy/TSD API.
-    Page     int    `long:"page"             default:"1"    description:"Page number"`
-    All      bool   `long:"all"                          description:"Fetch *every* page. Ignores --page."`
+	// Internally we convert to 0-based before calling the proxy/TSD API.
+	Page int  `long:"page"             default:"1"    description:"Page number"`
+	All  bool `long:"all"                          description:"Fetch *every* page. Ignores --page."`
 }
 
 var inboxOptionsParser = flags.NewParser(&inboxOptions, flags.None)
 
 var outboxOptions struct {
-	List bool `short:"l" long:"list" description:"Lists exported files"`
-    PerPage  int    `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
-    Page     int    `long:"page"             default:"1"    description:"Page number"`
-    All      bool   `long:"all"                          description:"Fetch *every* page. Ignores --page."`
+	List    bool `short:"l" long:"list" description:"Lists exported files"`
+	PerPage int  `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
+	Page    int  `long:"page"             default:"1"    description:"Page number"`
+	All     bool `long:"all"                          description:"Fetch *every* page. Ignores --page."`
 }
 
 var outboxOptionsParser = flags.NewParser(&outboxOptions, flags.None)
@@ -60,9 +60,10 @@ var resumablesOptions struct {
 var resumablesOptionsParser = flags.NewParser(&resumablesOptions, flags.None)
 
 var uploadingOptions struct {
-	FileName string `short:"f"  long:"file" description:"File or folder to upload" value-name:"FILE" required:"true"`
-	Resume   bool   `short:"r" long:"resume" description:"Resumes interrupted upload"`
-	Straight bool   `short:"b" long:"beta" description:"Upload the files without the proxy service;i.e. directly to tsd file api"`
+	FileName         string `short:"f"  long:"file" description:"File or folder to upload" value-name:"FILE" required:"true"`
+	Resume           bool   `short:"r" long:"resume" description:"Resumes interrupted upload"`
+	Straight         bool   `short:"b" long:"beta" description:"Upload the files without the proxy service;i.e. directly to tsd file api"`
+	NoDuplicateCheck bool   `long:"no-duplicate-check" description:"Skip checking whether the file already exists in the inbox before upload"`
 }
 
 var uploadingOptionsParser = flags.NewParser(&uploadingOptions, flags.None)
@@ -103,12 +104,12 @@ func main() {
 		}
 		if inboxOptions.List {
 			fileList, err := fileManager.ListFiles(
-                true,
-                // Convert user-facing 1-based page to backend 0-based index.
-                inboxOptions.Page-1,
-                inboxOptions.PerPage,
-                inboxOptions.All,
-            )
+				true,
+				// Convert user-facing 1-based page to backend 0-based index.
+				inboxOptions.Page-1,
+				inboxOptions.PerPage,
+				inboxOptions.All,
+			)
 			if err != nil {
 				if _, ok := err.(*files.FolderNotFoundError); ok {
 					log.Fatal(aurora.Red("Inbox Error: The user folder is empty or does not exist yet"))
@@ -122,19 +123,19 @@ func main() {
 			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}
-            for _, file := range *fileList {
-                _, err = fmt.Fprintln(
-                    tw,
-                    aurora.Blue(
-                        file.FileName +
-                            "\t " + strconv.FormatInt(file.Size, 10) + " bytes" +
-                            "\t " + file.ModifiedDate,
-                    ),
-                )
-                if err != nil {
-                    log.Fatal(aurora.Red(err))
-                }
-            }
+			for _, file := range *fileList {
+				_, err = fmt.Fprintln(
+					tw,
+					aurora.Blue(
+						file.FileName+
+							"\t "+strconv.FormatInt(file.Size, 10)+" bytes"+
+							"\t "+file.ModifiedDate,
+					),
+				)
+				if err != nil {
+					log.Fatal(aurora.Red(err))
+				}
+			}
 
 			err = tw.Flush()
 			if err != nil {
@@ -157,12 +158,12 @@ func main() {
 		}
 		if outboxOptions.List {
 			fileList, err := fileManager.ListFiles(
-                false,
-                // Convert user-facing 1-based page to backend 0-based index
-                outboxOptions.Page-1,
-                outboxOptions.PerPage,
-                outboxOptions.All,
-            )
+				false,
+				// Convert user-facing 1-based page to backend 0-based index
+				outboxOptions.Page-1,
+				outboxOptions.PerPage,
+				outboxOptions.All,
+			)
 			if err != nil {
 				if _, ok := err.(*files.FolderNotFoundError); ok {
 					log.Fatal(aurora.Red("Outbox Error: No data has been staged in the outbox yet"))
@@ -176,19 +177,19 @@ func main() {
 			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}
-            for _, file := range *fileList {
-                _, err = fmt.Fprintln(
-                    tw,
-                    aurora.Blue(
-                        file.FileName +
-                            "\t " + strconv.FormatInt(file.Size, 10) + " bytes" +
-                            "\t " + file.ModifiedDate,
-                    ),
-                )
-                if err != nil {
-                    log.Fatal(aurora.Red(err))
-                }
-            }
+			for _, file := range *fileList {
+				_, err = fmt.Fprintln(
+					tw,
+					aurora.Blue(
+						file.FileName+
+							"\t "+strconv.FormatInt(file.Size, 10)+" bytes"+
+							"\t "+file.ModifiedDate,
+					),
+				)
+				if err != nil {
+					log.Fatal(aurora.Red(err))
+				}
+			}
 			err = tw.Flush()
 			if err != nil {
 				log.Fatal(aurora.Red(err))
@@ -244,7 +245,12 @@ func main() {
 		if err != nil {
 			log.Fatal(aurora.Red(err))
 		}
-		err = streamer.Upload(uploadingOptions.FileName, uploadingOptions.Resume, uploadingOptions.Straight)
+		err = streamer.Upload(
+			uploadingOptions.FileName,
+			uploadingOptions.Resume,
+			uploadingOptions.Straight,
+			uploadingOptions.NoDuplicateCheck,
+		)
 		if err != nil {
 			log.Fatal(aurora.Red(err))
 		}
@@ -260,12 +266,12 @@ func main() {
 		if downloadingOptions.FileName == "" {
 			fmt.Println(aurora.Blue("File to export is not specified. Downloading the whole outbox folder."))
 			fileList, err := fileManager.ListFiles(
-			    false,
-			    // Convert user-facing 1-based page to backend 0-based index
-                outboxOptions.Page-1,
-                outboxOptions.PerPage,
-                outboxOptions.All,
-            )
+				false,
+				// Convert user-facing 1-based page to backend 0-based index
+				outboxOptions.Page-1,
+				outboxOptions.PerPage,
+				outboxOptions.All,
+			)
 			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}

--- a/cli/lega-commander/main.go
+++ b/cli/lega-commander/main.go
@@ -32,22 +32,22 @@ const (
 )
 
 var inboxOptions struct {
-	List    bool   `short:"l" long:"list" description:"Lists uploaded files"`
-	Delete  string `short:"d" long:"delete" description:"Deletes uploaded file by name"`
-	PerPage int    `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
+	List   bool   `short:"l" long:"list" description:"Lists uploaded files"`
+	Delete string `short:"d" long:"delete" description:"Deletes uploaded file by name"`
+	PerPage  int    `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
 	// Pagination note: --page is user-facing and 1-based (page=1 is the first page).
-	// Internally we convert to 0-based before calling the proxy/TSD API.
-	Page int  `long:"page"             default:"1"    description:"Page number"`
-	All  bool `long:"all"                          description:"Fetch *every* page. Ignores --page."`
+    // Internally we convert to 0-based before calling the proxy/TSD API.
+    Page     int    `long:"page"             default:"1"    description:"Page number"`
+    All      bool   `long:"all"                          description:"Fetch *every* page. Ignores --page."`
 }
 
 var inboxOptionsParser = flags.NewParser(&inboxOptions, flags.None)
 
 var outboxOptions struct {
-	List    bool `short:"l" long:"list" description:"Lists exported files"`
-	PerPage int  `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
-	Page    int  `long:"page"             default:"1"    description:"Page number"`
-	All     bool `long:"all"                          description:"Fetch *every* page. Ignores --page."`
+	List bool `short:"l" long:"list" description:"Lists exported files"`
+    PerPage  int    `short:"p" long:"per-page" default:"100"  description:"Items per page (max 50000)"`
+    Page     int    `long:"page"             default:"1"    description:"Page number"`
+    All      bool   `long:"all"                          description:"Fetch *every* page. Ignores --page."`
 }
 
 var outboxOptionsParser = flags.NewParser(&outboxOptions, flags.None)
@@ -60,8 +60,8 @@ var resumablesOptions struct {
 var resumablesOptionsParser = flags.NewParser(&resumablesOptions, flags.None)
 
 var uploadingOptions struct {
-	FileName         string `short:"f"  long:"file" description:"File or folder to upload" value-name:"FILE" required:"true"`
-	Resume           bool   `short:"r" long:"resume" description:"Resumes interrupted upload"`
+	FileName string `short:"f"  long:"file" description:"File or folder to upload" value-name:"FILE" required:"true"`
+	Resume   bool   `short:"r" long:"resume" description:"Resumes interrupted upload"`
 	Straight         bool   `short:"b" long:"beta" description:"Upload the files without the proxy service;i.e. directly to tsd file api"`
 	NoDuplicateCheck bool   `long:"no-duplicate-check" description:"Skip checking whether the file already exists in the inbox before upload"`
 }
@@ -104,12 +104,12 @@ func main() {
 		}
 		if inboxOptions.List {
 			fileList, err := fileManager.ListFiles(
-				true,
-				// Convert user-facing 1-based page to backend 0-based index.
-				inboxOptions.Page-1,
-				inboxOptions.PerPage,
-				inboxOptions.All,
-			)
+                true,
+                // Convert user-facing 1-based page to backend 0-based index.
+                inboxOptions.Page-1,
+                inboxOptions.PerPage,
+                inboxOptions.All,
+            )
 			if err != nil {
 				if _, ok := err.(*files.FolderNotFoundError); ok {
 					log.Fatal(aurora.Red("Inbox Error: The user folder is empty or does not exist yet"))
@@ -123,19 +123,19 @@ func main() {
 			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}
-			for _, file := range *fileList {
-				_, err = fmt.Fprintln(
-					tw,
-					aurora.Blue(
-						file.FileName+
-							"\t "+strconv.FormatInt(file.Size, 10)+" bytes"+
-							"\t "+file.ModifiedDate,
-					),
-				)
-				if err != nil {
-					log.Fatal(aurora.Red(err))
-				}
-			}
+            for _, file := range *fileList {
+                _, err = fmt.Fprintln(
+                    tw,
+                    aurora.Blue(
+                        file.FileName +
+                            "\t " + strconv.FormatInt(file.Size, 10) + " bytes" +
+                            "\t " + file.ModifiedDate,
+                    ),
+                )
+                if err != nil {
+                    log.Fatal(aurora.Red(err))
+                }
+            }
 
 			err = tw.Flush()
 			if err != nil {
@@ -158,12 +158,12 @@ func main() {
 		}
 		if outboxOptions.List {
 			fileList, err := fileManager.ListFiles(
-				false,
-				// Convert user-facing 1-based page to backend 0-based index
-				outboxOptions.Page-1,
-				outboxOptions.PerPage,
-				outboxOptions.All,
-			)
+                false,
+                // Convert user-facing 1-based page to backend 0-based index
+                outboxOptions.Page-1,
+                outboxOptions.PerPage,
+                outboxOptions.All,
+            )
 			if err != nil {
 				if _, ok := err.(*files.FolderNotFoundError); ok {
 					log.Fatal(aurora.Red("Outbox Error: No data has been staged in the outbox yet"))
@@ -177,19 +177,19 @@ func main() {
 			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}
-			for _, file := range *fileList {
-				_, err = fmt.Fprintln(
-					tw,
-					aurora.Blue(
-						file.FileName+
-							"\t "+strconv.FormatInt(file.Size, 10)+" bytes"+
-							"\t "+file.ModifiedDate,
-					),
-				)
-				if err != nil {
-					log.Fatal(aurora.Red(err))
-				}
-			}
+            for _, file := range *fileList {
+                _, err = fmt.Fprintln(
+                    tw,
+                    aurora.Blue(
+                        file.FileName +
+                            "\t " + strconv.FormatInt(file.Size, 10) + " bytes" +
+                            "\t " + file.ModifiedDate,
+                    ),
+                )
+                if err != nil {
+                    log.Fatal(aurora.Red(err))
+                }
+            }
 			err = tw.Flush()
 			if err != nil {
 				log.Fatal(aurora.Red(err))
@@ -266,12 +266,12 @@ func main() {
 		if downloadingOptions.FileName == "" {
 			fmt.Println(aurora.Blue("File to export is not specified. Downloading the whole outbox folder."))
 			fileList, err := fileManager.ListFiles(
-				false,
-				// Convert user-facing 1-based page to backend 0-based index
-				outboxOptions.Page-1,
-				outboxOptions.PerPage,
-				outboxOptions.All,
-			)
+			    false,
+			    // Convert user-facing 1-based page to backend 0-based index
+                outboxOptions.Page-1,
+                outboxOptions.PerPage,
+                outboxOptions.All,
+            )
 			if err != nil {
 				log.Fatal(aurora.Red(err))
 			}

--- a/cli/lega-commander/streaming/streaming.go
+++ b/cli/lega-commander/streaming/streaming.go
@@ -30,14 +30,14 @@ import (
 )
 
 type FileEntry struct {
-	FileName     string  `json:"fileName"`
-	Size         int64   `json:"size"`
-	ModifiedDate string  `json:"modifiedDate"`
-	Href         string  `json:"href"`
-	Exportable   bool    `json:"exportable"`
-	Reason       *string `json:"reason"`
-	MimeType     string  `json:"mimeType"`
-	Owner        string  `json:"owner"`
+    FileName     string  `json:"fileName"`
+    Size         int64   `json:"size"`
+    ModifiedDate string  `json:"modifiedDate"`
+    Href         string  `json:"href"`
+    Exportable   bool    `json:"exportable"`
+    Reason       *string `json:"reason"`
+    MimeType     string  `json:"mimeType"`
+    Owner        string  `json:"owner"`
 }
 
 // Streamer interface provides methods for uploading and downloading files from LocalEGA instance.
@@ -138,53 +138,53 @@ func (s defaultStreamer) Upload(path string, resume, straight, noDuplicateCheck 
 }
 
 func (s defaultStreamer) uploadFolder(folder *os.File, resume, straight, noDuplicateCheck bool) error {
-	var warnings []string
+    var warnings []string
 
-	entries, err := folder.Readdir(-1)
-	if err != nil {
-		return err
-	}
+    entries, err := folder.Readdir(-1)
+    if err != nil {
+        return err
+    }
 
-	for _, entry := range entries {
-		entryPath, err := filepath.Abs(filepath.Join(folder.Name(), entry.Name()))
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			subdir, err := os.Open(entryPath)
-			if err != nil {
-				return err
-			}
-			defer subdir.Close()
-			err = s.uploadFolder(subdir, resume, straight, noDuplicateCheck)
-			if err != nil {
-				return err
-			}
-			continue
-		}
+    for _, entry := range entries {
+        entryPath, err := filepath.Abs(filepath.Join(folder.Name(), entry.Name()))
+        if err != nil {
+            return err
+        }
+        if entry.IsDir() {
+            subdir, err := os.Open(entryPath)
+            if err != nil {
+                return err
+            }
+            defer subdir.Close()
+            err = s.uploadFolder(subdir, resume, straight, noDuplicateCheck)
+            if err != nil {
+                return err
+            }
+            continue
+        }
 
-		err = s.Upload(entryPath, resume, straight, noDuplicateCheck)
-		if err != nil {
-			errMsg := err.Error()
-			if strings.Contains(errMsg, "is already in the inbox") {
-				warnings = append(warnings,
-					fmt.Sprintf("Skipped %s: already in the inbox", entry.Name()))
-				continue
-			}
-			return err
-		}
-	}
-	if len(warnings) > 0 {
-		fmt.Println(aurora.Yellow("WARNING: Some files were skipped:"))
-		for _, w := range warnings {
-			fmt.Println(aurora.Yellow("  - " + w))
-		}
-	}
-	return nil
+        err = s.Upload(entryPath, resume, straight, noDuplicateCheck)
+        if err != nil {
+            errMsg := err.Error()
+            if strings.Contains(errMsg, "is already in the inbox") {
+                warnings = append(warnings,
+                    fmt.Sprintf("Skipped %s: already in the inbox", entry.Name()))
+                continue
+            }
+            return err
+        }
+    }
+    if len(warnings) > 0 {
+        fmt.Println(aurora.Yellow("WARNING: Some files were skipped:"))
+        for _, w := range warnings {
+            fmt.Println(aurora.Yellow("  - " + w))
+        }
+    }
+    return nil
 }
 
 func containsIgnoreCase(haystack, needle string) bool {
-	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+    return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
 }
 
 func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *string, offset, startChunk int64, noDuplicateCheck bool) error {
@@ -205,17 +205,18 @@ func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *s
 		} else {
 			for _, uploadedFile := range *filesList {
 				if fileName == filepath.Base(uploadedFile.FileName) {
-					return fmt.Errorf(
-						"File %s is already in the inbox.\n"+
-							"If you want to replace it, remove it first using:\n"+
-							"  lega-commander inbox -d %s",
-						file.Name(),
-						filepath.Base(uploadedFile.FileName),
-					)
+                    return fmt.Errorf(
+                        "File %s is already in the inbox.\n"+
+                            "If you want to replace it, remove it first using:\n"+
+                            "  lega-commander inbox -d %s",
+                        file.Name(),
+                        filepath.Base(uploadedFile.FileName),
+                    )
 				}
 			}
 		}
 	}
+
 	// Make sure the file to be uploaded is a crypt4gh encrypted file
 	if err = isCrypt4GHFile(file); err != nil {
 		return err
@@ -285,8 +286,8 @@ func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *s
 	checksum := hex.EncodeToString(hashFunction.Sum(nil))
 	fmt.Println("Assembling the uploaded parts of the file together in order to build it! Duration varies based on filesize.")
 	if uploadID == nil {
-		return errors.New("uploadID is nil at the finalization step")
-	}
+        return errors.New("uploadID is nil at the finalization step")
+    }
 	response, err := s.client.DoRequest(http.MethodPatch,
 		configuration.GetLocalEGAInstanceURL()+"/stream/"+url.QueryEscape(fileName),
 		nil,
@@ -333,13 +334,13 @@ func (s defaultStreamer) Download(fileName string) error {
 	if fileExists(fileName) {
 		return errors.New("File " + fileName + " exists locally, aborting.")
 	}
-	// Backend pagination is 0-based; start at page=0
+    // Backend pagination is 0-based; start at page=0
 	filesList, err := s.fileManager.ListFiles(
-		false,
-		0,
-		50000,
-		true,
-	)
+    false,
+    0,
+    50000,
+    true,
+    )
 	if err != nil {
 		return err
 	}

--- a/cli/lega-commander/streaming/streaming.go
+++ b/cli/lega-commander/streaming/streaming.go
@@ -30,21 +30,21 @@ import (
 )
 
 type FileEntry struct {
-    FileName     string  `json:"fileName"`
-    Size         int64   `json:"size"`
-    ModifiedDate string  `json:"modifiedDate"`
-    Href         string  `json:"href"`
-    Exportable   bool    `json:"exportable"`
-    Reason       *string `json:"reason"`
-    MimeType     string  `json:"mimeType"`
-    Owner        string  `json:"owner"`
+	FileName     string  `json:"fileName"`
+	Size         int64   `json:"size"`
+	ModifiedDate string  `json:"modifiedDate"`
+	Href         string  `json:"href"`
+	Exportable   bool    `json:"exportable"`
+	Reason       *string `json:"reason"`
+	MimeType     string  `json:"mimeType"`
+	Owner        string  `json:"owner"`
 }
 
 // Streamer interface provides methods for uploading and downloading files from LocalEGA instance.
 type Streamer interface {
-	Upload(path string, resume, straight bool) error
-	uploadFolder(folder *os.File, resume bool, straight bool) error
-	uploadFile(file *os.File, stat os.FileInfo, uploadID *string, offset int64, startChunk int64) error
+	Upload(path string, resume, straight, noDuplicateCheck bool) error
+	uploadFolder(folder *os.File, resume, straight, noDuplicateCheck bool) error
+	uploadFile(file *os.File, stat os.FileInfo, uploadID *string, offset int64, startChunk int64, noDuplicateCheck bool) error
 	Download(fileName string) error
 }
 
@@ -99,7 +99,7 @@ func NewStreamer(client *requests.Client, fileManager files.FileManager, resumab
 }
 
 // Upload method uploads file or folder to LocalEGA.
-func (s defaultStreamer) Upload(path string, resume, straight bool) error {
+func (s defaultStreamer) Upload(path string, resume, straight, noDuplicateCheck bool) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return err
@@ -110,7 +110,7 @@ func (s defaultStreamer) Upload(path string, resume, straight bool) error {
 		return err
 	}
 	if stat.IsDir() {
-		return s.uploadFolder(file, resume, straight)
+		return s.uploadFolder(file, resume, straight, noDuplicateCheck)
 	}
 	if resume {
 		fileName := filepath.Base(file.Name())
@@ -121,9 +121,9 @@ func (s defaultStreamer) Upload(path string, resume, straight bool) error {
 		for _, resumable := range *resumablesList {
 			if resumable.Name == fileName {
 				if !straight {
-					return s.uploadFile(file, stat, &resumable.ID, resumable.Size, resumable.Chunk)
+					return s.uploadFile(file, stat, &resumable.ID, resumable.Size, resumable.Chunk, noDuplicateCheck)
 				} else {
-					return s.uploadFileWithoutProxy(file, stat, &resumable.ID, resumable.Size, resumable.Chunk)
+					return s.uploadFileWithoutProxy(file, stat, &resumable.ID, resumable.Size, resumable.Chunk, noDuplicateCheck)
 				}
 
 			}
@@ -131,89 +131,91 @@ func (s defaultStreamer) Upload(path string, resume, straight bool) error {
 		return nil
 	}
 	if !straight {
-		return s.uploadFile(file, stat, nil, 0, 1)
+		return s.uploadFile(file, stat, nil, 0, 1, noDuplicateCheck)
 	} else {
-		return s.uploadFileWithoutProxy(file, stat, nil, 0, 1)
+		return s.uploadFileWithoutProxy(file, stat, nil, 0, 1, noDuplicateCheck)
 	}
 }
 
-func (s defaultStreamer) uploadFolder(folder *os.File, resume, straight bool) error {
-    var warnings []string
+func (s defaultStreamer) uploadFolder(folder *os.File, resume, straight, noDuplicateCheck bool) error {
+	var warnings []string
 
-    entries, err := folder.Readdir(-1)
-    if err != nil {
-        return err
-    }
+	entries, err := folder.Readdir(-1)
+	if err != nil {
+		return err
+	}
 
-    for _, entry := range entries {
-        entryPath, err := filepath.Abs(filepath.Join(folder.Name(), entry.Name()))
-        if err != nil {
-            return err
-        }
-        if entry.IsDir() {
-            subdir, err := os.Open(entryPath)
-            if err != nil {
-                return err
-            }
-            defer subdir.Close()
-            err = s.uploadFolder(subdir, resume, straight)
-            if err != nil {
-                return err
-            }
-            continue
-        }
+	for _, entry := range entries {
+		entryPath, err := filepath.Abs(filepath.Join(folder.Name(), entry.Name()))
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			subdir, err := os.Open(entryPath)
+			if err != nil {
+				return err
+			}
+			defer subdir.Close()
+			err = s.uploadFolder(subdir, resume, straight, noDuplicateCheck)
+			if err != nil {
+				return err
+			}
+			continue
+		}
 
-        err = s.Upload(entryPath, resume, straight)
-        if err != nil {
-            errMsg := err.Error()
-            if strings.Contains(errMsg, "is already in the inbox") {
-                warnings = append(warnings,
-                    fmt.Sprintf("Skipped %s: already in the inbox", entry.Name()))
-                continue
-            }
-            return err
-        }
-    }
-    if len(warnings) > 0 {
-        fmt.Println(aurora.Yellow("WARNING: Some files were skipped:"))
-        for _, w := range warnings {
-            fmt.Println(aurora.Yellow("  - " + w))
-        }
-    }
-    return nil
+		err = s.Upload(entryPath, resume, straight, noDuplicateCheck)
+		if err != nil {
+			errMsg := err.Error()
+			if strings.Contains(errMsg, "is already in the inbox") {
+				warnings = append(warnings,
+					fmt.Sprintf("Skipped %s: already in the inbox", entry.Name()))
+				continue
+			}
+			return err
+		}
+	}
+	if len(warnings) > 0 {
+		fmt.Println(aurora.Yellow("WARNING: Some files were skipped:"))
+		for _, w := range warnings {
+			fmt.Println(aurora.Yellow("  - " + w))
+		}
+	}
+	return nil
 }
 
 func containsIgnoreCase(haystack, needle string) bool {
-    return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
 }
 
-func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *string, offset, startChunk int64) error {
+func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *string, offset, startChunk int64, noDuplicateCheck bool) error {
 	fileName := filepath.Base(file.Name())
+	var err error
 
 	// List user's files already in inbox to avoid accidental overwrites
 	// Backend pagination is 0-based; start at page=0
-	filesList, err := s.fileManager.ListFiles(
-	true,
-    0,
-    50000,
-    true, )
-	if err != nil {
-		fmt.Println("Could not read previous uploaded files, this is ok if it's your first upload")
-		//		return err
-	} else {
-		for _, uploadedFile := range *filesList {
-			if fileName == filepath.Base(uploadedFile.FileName) {
-                return fmt.Errorf(
-                    "File %s is already in the inbox.\n"+
-                        "If you want to replace it, remove it first using:\n"+
-                        "  lega-commander inbox -d %s",
-                    file.Name(),
-                    filepath.Base(uploadedFile.FileName),
-                )
+	if !noDuplicateCheck {
+		filesList, err := s.fileManager.ListFiles(
+			true,
+			0,
+			50000,
+			true,
+		)
+		if err != nil {
+			fmt.Println("Could not read previous uploaded files, this is ok if it's your first upload")
+		} else {
+			for _, uploadedFile := range *filesList {
+				if fileName == filepath.Base(uploadedFile.FileName) {
+					return fmt.Errorf(
+						"File %s is already in the inbox.\n"+
+							"If you want to replace it, remove it first using:\n"+
+							"  lega-commander inbox -d %s",
+						file.Name(),
+						filepath.Base(uploadedFile.FileName),
+					)
+				}
 			}
 		}
 	}
-
 	// Make sure the file to be uploaded is a crypt4gh encrypted file
 	if err = isCrypt4GHFile(file); err != nil {
 		return err
@@ -283,8 +285,8 @@ func (s defaultStreamer) uploadFile(file *os.File, stat os.FileInfo, uploadID *s
 	checksum := hex.EncodeToString(hashFunction.Sum(nil))
 	fmt.Println("Assembling the uploaded parts of the file together in order to build it! Duration varies based on filesize.")
 	if uploadID == nil {
-        return errors.New("uploadID is nil at the finalization step")
-    }
+		return errors.New("uploadID is nil at the finalization step")
+	}
 	response, err := s.client.DoRequest(http.MethodPatch,
 		configuration.GetLocalEGAInstanceURL()+"/stream/"+url.QueryEscape(fileName),
 		nil,
@@ -331,13 +333,13 @@ func (s defaultStreamer) Download(fileName string) error {
 	if fileExists(fileName) {
 		return errors.New("File " + fileName + " exists locally, aborting.")
 	}
-    // Backend pagination is 0-based; start at page=0
+	// Backend pagination is 0-based; start at page=0
 	filesList, err := s.fileManager.ListFiles(
-    false,
-    0,
-    50000,
-    true,
-    )
+		false,
+		0,
+		50000,
+		true,
+	)
 	if err != nil {
 		return err
 	}
@@ -438,18 +440,25 @@ func (s defaultStreamer) getTSDtoken(c conf.Configuration) (string, jwt.MapClaim
 	return extractClaims(response)
 }
 
-func (s *defaultStreamer) uploadFileWithoutProxy(file *os.File, stat os.FileInfo, uploadID *string, offset, startChunk int64) error {
+func (s *defaultStreamer) uploadFileWithoutProxy(file *os.File, stat os.FileInfo, uploadID *string, offset, startChunk int64, noDuplicateCheck bool) error {
 	fileName := filepath.Base(file.Name())
+	var err error
+
 	// Backend pagination is 0-based; start at page=0
-	filesList, err := s.fileManager.ListFiles(
-    true, 0, 50000, true,
-	)
-	if err != nil {
-		return err
-	}
-	for _, uploadedFile := range *filesList {
-		if fileName == filepath.Base(uploadedFile.FileName) {
-			return errors.New("File " + file.Name() + " is already uploaded. Please, remove it from the Inbox first: lega-commander files -d " + filepath.Base(uploadedFile.FileName))
+	if !noDuplicateCheck {
+		filesList, err := s.fileManager.ListFiles(
+			true,
+			0,
+			50000,
+			true,
+		)
+		if err != nil {
+			return err
+		}
+		for _, uploadedFile := range *filesList {
+			if fileName == filepath.Base(uploadedFile.FileName) {
+				return errors.New("File " + file.Name() + " is already uploaded. Please, remove it from the Inbox first: lega-commander inbox -d " + filepath.Base(uploadedFile.FileName))
+			}
 		}
 	}
 	configuration := conf.NewConfiguration()

--- a/cli/lega-commander/streaming/streaming_test.go
+++ b/cli/lega-commander/streaming/streaming_test.go
@@ -62,73 +62,73 @@ type mockClient struct {
 }
 
 func (mockClient) DoRequest(
-    method, url string,
-    _ io.Reader,
-    headers, params map[string]string,
-    _, _ string,
+	method, url string,
+	_ io.Reader,
+	headers, params map[string]string,
+	_, _ string,
 ) (*http.Response, error) {
-    //auth check
-    if !strings.HasPrefix(headers["Proxy-Authorization"], "Bearer ") {
-        return &http.Response{
-            StatusCode: http.StatusUnauthorized,
-            Body:       ioutil.NopCloser(strings.NewReader("")),
-        }, nil
-    }
+	//auth check
+	if !strings.HasPrefix(headers["Proxy-Authorization"], "Bearer ") {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}
 
-    // list files (inbox / outbox)
-    if strings.HasSuffix(url, "/files") {
-        page := params["page"]
-        if page != "" && page != "0" {
-            empty := ioutil.NopCloser(strings.NewReader(`{"files":[]}`))
-            return &http.Response{StatusCode: http.StatusOK, Body: empty}, nil
-        }
-        var body io.ReadCloser
-        if params["inbox"] == "" || params["inbox"] == "true" {
-            body = ioutil.NopCloser(
-                strings.NewReader(`{"files":[{"fileName":"test.enc","size":100,"modifiedDate":"2010"}]}`),
-            )
-        } else {
-            body = ioutil.NopCloser(
-                strings.NewReader(`{"files":[{"fileName":"test2.enc","size":100,"modifiedDate":"2010"}]}`),
-            )
-        }
-        return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
-    }
+	// list files (inbox / outbox)
+	if strings.HasSuffix(url, "/files") {
+		page := params["page"]
+		if page != "" && page != "0" {
+			empty := ioutil.NopCloser(strings.NewReader(`{"files":[]}`))
+			return &http.Response{StatusCode: http.StatusOK, Body: empty}, nil
+		}
+		var body io.ReadCloser
+		if params["inbox"] == "" || params["inbox"] == "true" {
+			body = ioutil.NopCloser(
+				strings.NewReader(`{"files":[{"fileName":"test.enc","size":100,"modifiedDate":"2010"}]}`),
+			)
+		} else {
+			body = ioutil.NopCloser(
+				strings.NewReader(`{"files":[{"fileName":"test2.enc","size":100,"modifiedDate":"2010"}]}`),
+			)
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	}
 
-    // resumable / streaming endpoints (mock PATCH/GET)
-    if strings.Contains(url, "/stream/") {
-        if method == http.MethodGet {
-            // Simulate a file download
-            return &http.Response{
-                StatusCode: http.StatusOK,
-                Body: ioutil.NopCloser(strings.NewReader("test")),
-            }, nil
-        }
-        if method == http.MethodPatch {
-            body := ioutil.NopCloser(strings.NewReader(`{"id":"mock-upload-id"}`))
-            return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
-        }
-    }
+	// resumable / streaming endpoints (mock PATCH/GET)
+	if strings.Contains(url, "/stream/") {
+		if method == http.MethodGet {
+			// Simulate a file download
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(strings.NewReader("test")),
+			}, nil
+		}
+		if method == http.MethodPatch {
+			body := ioutil.NopCloser(strings.NewReader(`{"id":"mock-upload-id"}`))
+			return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+		}
+	}
 
-    return nil, nil
+	return nil, nil
 }
 
 func TestUploadedFileExists(t *testing.T) {
-	err := uploader.Upload(existingFile.Name(), false, false)
+	err := uploader.Upload(existingFile.Name(), false, false, false)
 	if err == nil {
 		t.Error()
 	}
 }
 
 func TestUploadFile(t *testing.T) {
-	err := uploader.Upload(file.Name(), false, false)
+	err := uploader.Upload(file.Name(), false, false, false)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
 func TestUploadFolder(t *testing.T) {
-	err := uploader.Upload(dir, false, false)
+	err := uploader.Upload(dir, false, false, false)
 	if err == nil || !strings.HasSuffix(err.Error(), "not a Crypt4GH file") {
 		t.Error(err)
 	}
@@ -142,7 +142,7 @@ func TestDownloadFileRemoteDoesntExist(t *testing.T) {
 }
 
 func TestDownloadFileRemoteExists(t *testing.T) {
-    os.Remove("test2.enc")
+	os.Remove("test2.enc")
 	err := uploader.Download("test2.enc")
 	if err != nil {
 		t.Error(err)

--- a/cli/lega-commander/streaming/streaming_test.go
+++ b/cli/lega-commander/streaming/streaming_test.go
@@ -62,55 +62,55 @@ type mockClient struct {
 }
 
 func (mockClient) DoRequest(
-	method, url string,
-	_ io.Reader,
-	headers, params map[string]string,
-	_, _ string,
+    method, url string,
+    _ io.Reader,
+    headers, params map[string]string,
+    _, _ string,
 ) (*http.Response, error) {
-	//auth check
-	if !strings.HasPrefix(headers["Proxy-Authorization"], "Bearer ") {
-		return &http.Response{
-			StatusCode: http.StatusUnauthorized,
-			Body:       ioutil.NopCloser(strings.NewReader("")),
-		}, nil
-	}
+    //auth check
+    if !strings.HasPrefix(headers["Proxy-Authorization"], "Bearer ") {
+        return &http.Response{
+            StatusCode: http.StatusUnauthorized,
+            Body:       ioutil.NopCloser(strings.NewReader("")),
+        }, nil
+    }
 
-	// list files (inbox / outbox)
-	if strings.HasSuffix(url, "/files") {
-		page := params["page"]
-		if page != "" && page != "0" {
-			empty := ioutil.NopCloser(strings.NewReader(`{"files":[]}`))
-			return &http.Response{StatusCode: http.StatusOK, Body: empty}, nil
-		}
-		var body io.ReadCloser
-		if params["inbox"] == "" || params["inbox"] == "true" {
-			body = ioutil.NopCloser(
-				strings.NewReader(`{"files":[{"fileName":"test.enc","size":100,"modifiedDate":"2010"}]}`),
-			)
-		} else {
-			body = ioutil.NopCloser(
-				strings.NewReader(`{"files":[{"fileName":"test2.enc","size":100,"modifiedDate":"2010"}]}`),
-			)
-		}
-		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
-	}
+    // list files (inbox / outbox)
+    if strings.HasSuffix(url, "/files") {
+        page := params["page"]
+        if page != "" && page != "0" {
+            empty := ioutil.NopCloser(strings.NewReader(`{"files":[]}`))
+            return &http.Response{StatusCode: http.StatusOK, Body: empty}, nil
+        }
+        var body io.ReadCloser
+        if params["inbox"] == "" || params["inbox"] == "true" {
+            body = ioutil.NopCloser(
+                strings.NewReader(`{"files":[{"fileName":"test.enc","size":100,"modifiedDate":"2010"}]}`),
+            )
+        } else {
+            body = ioutil.NopCloser(
+                strings.NewReader(`{"files":[{"fileName":"test2.enc","size":100,"modifiedDate":"2010"}]}`),
+            )
+        }
+        return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+    }
 
-	// resumable / streaming endpoints (mock PATCH/GET)
-	if strings.Contains(url, "/stream/") {
-		if method == http.MethodGet {
-			// Simulate a file download
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       ioutil.NopCloser(strings.NewReader("test")),
-			}, nil
-		}
-		if method == http.MethodPatch {
-			body := ioutil.NopCloser(strings.NewReader(`{"id":"mock-upload-id"}`))
-			return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
-		}
-	}
+    // resumable / streaming endpoints (mock PATCH/GET)
+    if strings.Contains(url, "/stream/") {
+        if method == http.MethodGet {
+            // Simulate a file download
+            return &http.Response{
+                StatusCode: http.StatusOK,
+                Body: ioutil.NopCloser(strings.NewReader("test")),
+            }, nil
+        }
+        if method == http.MethodPatch {
+            body := ioutil.NopCloser(strings.NewReader(`{"id":"mock-upload-id"}`))
+            return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+        }
+    }
 
-	return nil, nil
+    return nil, nil
 }
 
 func TestUploadedFileExists(t *testing.T) {
@@ -142,7 +142,7 @@ func TestDownloadFileRemoteDoesntExist(t *testing.T) {
 }
 
 func TestDownloadFileRemoteExists(t *testing.T) {
-	os.Remove("test2.enc")
+    os.Remove("test2.enc")
 	err := uploader.Download("test2.enc")
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This change adds a short-term workaround by allowing users to skip that pre-upload duplicate check when needed.

Notes:

- default behavior is unchanged
- the flag is opt-in
- applies to both proxy and direct (--beta) upload paths
- this is a mitigation, not the final fix