### PR TITLE
fix(proxy, lega-commander): Emit pipeline notification after direct upload (-b mode)

### DIFF
--- a/cli/lega-commander/streaming/streaming.go
+++ b/cli/lega-commander/streaming/streaming.go
@@ -483,6 +483,7 @@ func (s *defaultStreamer) uploadFileWithoutProxy(file *os.File, stat os.FileInfo
 		return err
 	}
 	buffer := make([]byte, configuration.GetChunkSize()*1024*1024)
+	hashFunction := sha256.New()
 	for i := startChunk; true; i++ {
 		read, err := file.Read(buffer)
 		if err != nil {
@@ -492,6 +493,7 @@ func (s *defaultStreamer) uploadFileWithoutProxy(file *os.File, stat os.FileInfo
 			break
 		}
 		chunk := buffer[:read]
+		hashFunction.Write(chunk)
 		if err != nil {
 			return err
 		}
@@ -556,5 +558,30 @@ func (s *defaultStreamer) uploadFileWithoutProxy(file *os.File, stat os.FileInfo
 		return err
 	}
 	bar.Finish()
+
+	checksum := hex.EncodeToString(hashFunction.Sum(nil))
+	notifyResp, err := s.client.DoRequest(
+		http.MethodPost,
+		configuration.GetLocalEGAInstanceURL()+"/stream/"+url.QueryEscape(fileName)+"/notify",
+		nil,
+		map[string]string{"Proxy-Authorization": "Bearer " + configuration.GetElixirAAIToken()},
+		map[string]string{
+			"fileSize": strconv.FormatInt(totalSize, 10),
+			"sha256":   checksum,
+		},
+		configuration.GetCentralEGAUsername(),
+		configuration.GetCentralEGAPassword(),
+	)
+	if err != nil {
+		return fmt.Errorf("upload succeeded but pipeline notification failed: %w", err)
+	}
+	defer notifyResp.Body.Close()
+	if notifyResp.StatusCode != http.StatusOK {
+		respBody, _ := ioutil.ReadAll(notifyResp.Body)
+		return fmt.Errorf(
+			"upload succeeded but pipeline notification failed (%d): %s",
+			notifyResp.StatusCode, string(respBody))
+	}
+
 	return nil
 }

--- a/cli/lega-commander/streaming/streaming_test.go
+++ b/cli/lega-commander/streaming/streaming_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 var uploader Streamer
+var directUploader Streamer
 var dir string
 var file *os.File
 var existingFile *os.File
@@ -47,6 +48,12 @@ func setup() {
 	if err != nil {
 		log.Fatal(aurora.Red(err))
 	}
+	_ = os.Setenv("TSD_PROXY_URL", "http://localhost")
+	_ = os.Setenv("TSD_PROJ_NAME", "p2184")
+	directUploader, err = NewStreamer(&client, filesManager, resumablesManager, true)
+	if err != nil {
+		log.Fatal(aurora.Red(err))
+	}
 	dir = "../test/files"
 	file, err = os.Open("../test/files/sample.txt.enc")
 	if err != nil {
@@ -67,10 +74,31 @@ func (mockClient) DoRequest(
 	headers, params map[string]string,
 	_, _ string,
 ) (*http.Response, error) {
+	// TSD token exchange (used by -b mode, no Proxy-Authorization header)
+	if strings.Contains(url, "/auth/lifesc/token") && method == http.MethodPost {
+		mockJWT := "eyJhbGciOiJub25lIn0.eyJ1c2VyIjoidGVzdHVzZXIifQ."
+		body := ioutil.NopCloser(strings.NewReader(`{"token":"` + mockJWT + `"}`))
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	}
+
+	// TSD direct file upload (used by -b mode, uses Authorization not Proxy-Authorization)
+	if strings.Contains(url, "/files/") && method == http.MethodPatch {
+		body := ioutil.NopCloser(strings.NewReader(`{"id":"mock-upload-id"}`))
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	}
+
 	//auth check
 	if !strings.HasPrefix(headers["Proxy-Authorization"], "Bearer ") {
 		return &http.Response{
 			StatusCode: http.StatusUnauthorized,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+		}, nil
+	}
+
+	// notify endpoint for direct upload completion
+	if strings.Contains(url, "/notify") && method == http.MethodPost {
+		return &http.Response{
+			StatusCode: http.StatusOK,
 			Body:       ioutil.NopCloser(strings.NewReader("")),
 		}, nil
 	}
@@ -177,9 +205,18 @@ func TestDownloadFileLocalExists(t *testing.T) {
 	}
 }
 
+func TestDirectUploadFile(t *testing.T) {
+	err := directUploader.Upload(file.Name(), false, true, false)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
 func teardown() {
 	_ = os.Unsetenv("CENTRAL_EGA_USERNAME")
 	_ = os.Unsetenv("CENTRAL_EGA_PASSWORD")
 	_ = os.Unsetenv("LOCAL_EGA_INSTANCE_URL")
 	_ = os.Unsetenv("ELIXIR_AAI_TOKEN")
+	_ = os.Unsetenv("TSD_PROXY_URL")
+	_ = os.Unsetenv("TSD_PROJ_NAME")
 }

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/CredentialsMappingAspect.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/CredentialsMappingAspect.java
@@ -38,7 +38,8 @@ public class CredentialsMappingAspect {
    */
   @AfterReturning(
       pointcut =
-          "execution(public * no.elixir.fega.ltp.controllers.rest.ProxyController.stream(..))",
+          "execution(public * no.elixir.fega.ltp.controllers.rest.ProxyController.stream(..)) || "
+              + "execution(public * no.elixir.fega.ltp.controllers.rest.ProxyController.notifyUploadComplete(..))",
       returning = "result")
   public void mapCredentials(Object result) {
     Object egaUsernameAttr = request.getAttribute(EGA_USERNAME);

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
@@ -140,10 +140,18 @@ public class PublishMQAspect {
       return;
     }
 
+    long parsedFileSize;
+    try {
+      parsedFileSize = Long.parseLong(fileSize.toString());
+    } catch (NumberFormatException e) {
+      log.error("Invalid FILE_SIZE attribute: {}", fileSize);
+      return;
+    }
+
     FileDescriptor fileDescriptor = new FileDescriptor();
     fileDescriptor.setUser(elixirId.toString());
     fileDescriptor.setFilePath(buildInboxPath(fileName.toString()));
-    fileDescriptor.setFileSize(Long.parseLong(fileSize.toString()));
+    fileDescriptor.setFileSize(parsedFileSize);
     fileDescriptor.setFileLastModified(System.currentTimeMillis() / 1000);
     fileDescriptor.setOperation(Operation.UPLOAD.name().toLowerCase());
     fileDescriptor.setEncryptedIntegrity(

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
@@ -110,6 +110,48 @@ public class PublishMQAspect {
   }
 
   /**
+   * Publishes {@code FileDescriptor} to the MQ upon direct upload (-b mode) completion
+   * notification.
+   *
+   * @param result Object returned by the notify endpoint.
+   */
+  @AfterReturning(
+      pointcut =
+          "execution(public * no.elixir.fega.ltp.controllers.rest.ProxyController.notifyUploadComplete(..))",
+      returning = "result")
+  public void publishDirectUploadNotification(Object result) {
+    if (!(result instanceof ResponseEntity<?> response)
+        || !response.getStatusCode().is2xxSuccessful()) {
+      return;
+    }
+
+    Object elixirId = request.getAttribute(ELIXIR_ID);
+    Object fileName = request.getAttribute(FILE_NAME);
+    Object fileSize = request.getAttribute(FILE_SIZE);
+    Object sha256 = request.getAttribute(SHA256);
+    if (elixirId == null || fileName == null || fileSize == null || sha256 == null) {
+      log.error(
+          "Missing required request attributes for direct upload notification: "
+              + "ELIXIR_ID={}, FILE_NAME={}, FILE_SIZE={}, SHA256={}",
+          elixirId,
+          fileName,
+          fileSize,
+          sha256);
+      return;
+    }
+
+    FileDescriptor fileDescriptor = new FileDescriptor();
+    fileDescriptor.setUser(elixirId.toString());
+    fileDescriptor.setFilePath(buildInboxPath(fileName.toString()));
+    fileDescriptor.setFileSize(Long.parseLong(fileSize.toString()));
+    fileDescriptor.setFileLastModified(System.currentTimeMillis() / 1000);
+    fileDescriptor.setOperation(Operation.UPLOAD.name().toLowerCase());
+    fileDescriptor.setEncryptedIntegrity(
+        new EncryptedIntegrity[] {new EncryptedIntegrity(SHA256.toLowerCase(), sha256.toString())});
+    publishMessage(fileDescriptor, Operation.UPLOAD.name().toLowerCase());
+  }
+
+  /**
    * Publishes <code>FileDescriptor</code> to the MQ upon file removal.
    *
    * @param result Object returned by the proxied method.

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
@@ -209,7 +209,6 @@ public class ProxyController {
    * message publication for the SDA pipeline.
    *
    * @param request HTTP servlet request (for setting attributes consumed by aspects).
-   * @param bearerAuthorization Elixir AAI token.
    * @param fileName Uploaded file name.
    * @param fileSize Total file size in bytes.
    * @param sha256 SHA-256 checksum of the entire file.
@@ -218,7 +217,6 @@ public class ProxyController {
   @PostMapping("/stream/{fileName}/notify")
   public ResponseEntity<?> notifyUploadComplete(
       jakarta.servlet.http.HttpServletRequest request,
-      @RequestHeader(HttpHeaders.PROXY_AUTHORIZATION) String bearerAuthorization,
       @PathVariable("fileName") String fileName,
       @RequestParam("fileSize") String fileSize,
       @RequestParam("sha256") String sha256) {

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
@@ -205,6 +205,49 @@ public class ProxyController {
   }
 
   /**
+   * Notifies the proxy that a direct upload (-b mode) has completed. Triggers the RabbitMQ inbox
+   * message publication for the SDA pipeline.
+   *
+   * @param request HTTP servlet request (for setting attributes consumed by aspects).
+   * @param bearerAuthorization Elixir AAI token.
+   * @param fileName Uploaded file name.
+   * @param fileSize Total file size in bytes.
+   * @param sha256 SHA-256 checksum of the entire file.
+   * @return 200 OK on success, 400 on invalid input.
+   */
+  @PostMapping("/stream/{fileName}/notify")
+  public ResponseEntity<?> notifyUploadComplete(
+      jakarta.servlet.http.HttpServletRequest request,
+      @RequestHeader(HttpHeaders.PROXY_AUTHORIZATION) String bearerAuthorization,
+      @PathVariable("fileName") String fileName,
+      @RequestParam("fileSize") String fileSize,
+      @RequestParam("sha256") String sha256) {
+
+    if (fileName.contains("..") || fileName.contains("/") || fileName.contains("\\")) {
+      return ResponseEntity.badRequest().body("Invalid file name.");
+    }
+    long parsedFileSize;
+    try {
+      parsedFileSize = Long.parseLong(fileSize);
+    } catch (NumberFormatException e) {
+      return ResponseEntity.badRequest().body("fileSize must be a valid number.");
+    }
+    if (parsedFileSize <= 0) {
+      return ResponseEntity.badRequest().body("fileSize must be positive.");
+    }
+    if (sha256 == null || !sha256.matches("^[a-fA-F0-9]{64}$")) {
+      return ResponseEntity.badRequest().body("sha256 must be a 64-character hex string.");
+    }
+
+    request.setAttribute(no.elixir.fega.ltp.aspects.ProcessArgumentsAspect.FILE_NAME, fileName);
+    request.setAttribute(no.elixir.fega.ltp.aspects.ProcessArgumentsAspect.FILE_SIZE, fileSize);
+    request.setAttribute(no.elixir.fega.ltp.aspects.ProcessArgumentsAspect.SHA256, sha256);
+    request.setAttribute(no.elixir.fega.ltp.aspects.ProcessArgumentsAspect.CHUNK, "end");
+
+    return ResponseEntity.ok().build();
+  }
+
+  /**
    * Gets TSD token.
    *
    * @param bearerAuthorization Elixir AAI token.


### PR DESCRIPTION
## Problem

When using the `-b` (direct upload) flag in `lega-commander`, all file chunks including the final `chunk=end` are sent directly to the TSD File API, bypassing the proxy. The proxy never sees the finalization request, so `PublishMQAspect` never fires and the `files.inbox` RabbitMQ message is never published. The file lands in TSD but the SDA ingest pipeline is never notified.

This is a showstopper for production use of `-b`.

## Fix

**Proxy** -- new `POST /stream/{fileName}/notify?fileSize={size}&sha256={hash}` endpoint:
- Authenticated via the existing Elixir AAI + CEGA aspect chain (no new auth paths)
- Validates input: rejects path traversal in fileName, validates sha256 format and fileSize
- Sets request attributes so the existing `PublishMQAspect` and `CredentialsMappingAspect` fire normally
- New `@AfterReturning` pointcut on `PublishMQAspect` builds and publishes the same `FileDescriptor` as the normal upload path

**lega-commander** -- two additions to `uploadFileWithoutProxy()`:
- Rolling SHA-256 hash computation during upload (matching the pattern in the normal `uploadFile()`)
- After `chunk=end` succeeds on TSD, POST to the proxy's notify endpoint with fileSize and sha256

## Files changed

| File | Change |
|------|--------|
| `ProxyController.java` | Add `notifyUploadComplete()` endpoint |
| `PublishMQAspect.java` | Add `publishDirectUploadNotification()` pointcut |
| `CredentialsMappingAspect.java` | Widen pointcut to include notify endpoint |
| `streaming/streaming.go` | Add SHA-256 hash + proxy notification to `-b` path |
| `streaming/streaming_test.go` | Add mock handler + `TestDirectUploadFile` |

## Security

- Auth uses the same Elixir AAI + CEGA credential chain as all other proxy endpoints
- `fileName` as path variable is protected against path separators by Spring URL routing; additional `..` and `/` validation in the controller
- sha256 validated against `^[a-fA-F0-9]{64}$`
- The proxy does not verify file existence in TSD (same trust model as normal uploads where client-reported sha256/fileSize are passed through). SDA pipeline independently verifies checksums during ingest/verify.

## Testing

- All existing proxy and lega-commander tests pass
- New `TestDirectUploadFile` covers the full `-b` upload path including hash computation and proxy notification

Closes #776