### PR TITLE
Verify Elixir AAI JWT signature at proxy auth boundary

### DIFF
--- a/e2eTests/src/test/java/no/elixir/e2eTests/FEGAIntegrationTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/FEGAIntegrationTest.java
@@ -2,6 +2,7 @@ package no.elixir.e2eTests;
 
 import no.elixir.e2eTests.core.BaseE2ETest;
 import no.elixir.e2eTests.features.*;
+import no.elixir.e2eTests.negative.*;
 import no.elixir.e2eTests.utils.CommonUtils;
 import org.junit.jupiter.api.*;
 
@@ -16,6 +17,14 @@ public class FEGAIntegrationTest {
   @AfterAll
   static void cleanup() {
     BaseE2ETest.cleanupTestEnvironment();
+  }
+
+  @Test
+  @Order(0)
+  void C1JwtSignatureVerificationTest() throws Exception {
+    // Negative security check: forged-signature JWT must be rejected before
+    // the pipeline runs. If this fails, auth is bypassable (audit finding C1).
+    C1JwtSignatureVerificationTest.verifyForgedJwtIsRejected();
   }
 
   @Test

--- a/e2eTests/src/test/java/no/elixir/e2eTests/negative/C1JwtSignatureVerificationTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/negative/C1JwtSignatureVerificationTest.java
@@ -23,9 +23,8 @@ import no.elixir.e2eTests.core.E2EState;
  * token — but signs it with a freshly-generated RSA key the proxy does not trust. A correctly
  * implemented resource server rejects such a request on signature verification alone.
  *
- * <p>Currently this passes because TSD's token-exchange endpoint verifies the signature
- * downstream; if that safety net is ever removed, this test fails and we know we've lost defense in
- * depth.
+ * <p>The proxy now verifies the signature at the auth boundary ({@code TokenService.parseVerified})
+ * before any downstream call is made. A failure here means the proxy-level check regressed.
  */
 public class C1JwtSignatureVerificationTest {
 

--- a/e2eTests/src/test/java/no/elixir/e2eTests/negative/C1JwtSignatureVerificationTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/negative/C1JwtSignatureVerificationTest.java
@@ -1,0 +1,89 @@
+package no.elixir.e2eTests.negative;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jsonwebtoken.Jwts;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import no.elixir.e2eTests.constants.Strings;
+import no.elixir.e2eTests.core.E2EState;
+
+/**
+ * Negative security check for audit finding C1 (SECURITY-AUDIT-2026-03-27): the Elixir AAI JWT
+ * signature must be verified before the proxy reads any claim from it. Today, {@code AAIAspect}
+ * reads {@code aud} and {@code sub} via a base64 decode with no signature check, which lets a
+ * hand-crafted token impersonate any Elixir ID.
+ *
+ * <p>This check forges a structurally-valid JWT — same header and claim shape as a legitimate e2e
+ * token — but signs it with a freshly-generated RSA key the proxy does not trust. A correctly
+ * implemented resource server rejects such a request on signature verification alone.
+ *
+ * <p>Currently this passes because TSD's token-exchange endpoint verifies the signature
+ * downstream; if that safety net is ever removed, this test fails and we know we've lost defense in
+ * depth.
+ */
+public class C1JwtSignatureVerificationTest {
+
+  public static void verifyForgedJwtIsRejected() throws Exception {
+    E2EState.log.info("C1 negative check: sending JWT signed by an untrusted key...");
+    String forgedToken = mintTokenWithAttackerKey();
+
+    String url =
+        String.format(
+            "https://%s:%s/files?inbox=true",
+            E2EState.env.getProxyHost(), E2EState.env.getProxyPort());
+
+    HttpResponse<String> response =
+        Unirest.get(url)
+            .basicAuth(E2EState.env.getCegaAuthUsername(), E2EState.env.getCegaAuthPassword())
+            .header("Proxy-Authorization", "Bearer " + forgedToken)
+            .asString();
+
+    int status = response.getStatus();
+    E2EState.log.info("C1 negative check: proxy returned HTTP {}", status);
+    assertTrue(
+        status == 401 || status == 403,
+        String.format(
+            "Forged-signature JWT must be rejected by /files but got HTTP %d. "
+                + "Response body: %s. "
+                + "A 2xx here means C1 is live: the proxy trusted an unverified token.",
+            status, response.getBody()));
+  }
+
+  private static String mintTokenWithAttackerKey() throws Exception {
+    KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+    generator.initialize(2048);
+    KeyPair attackerKeys = generator.generateKeyPair();
+
+    Map<String, Object> ga4ghVisa = new HashMap<>();
+    ga4ghVisa.put("asserted", Strings.VISA_ASSERTED);
+    ga4ghVisa.put("by", Strings.VISA_BY);
+    ga4ghVisa.put("source", Strings.VISA_SOURCE);
+    ga4ghVisa.put("type", Strings.VISA_TYPE);
+    ga4ghVisa.put("value", String.format(Strings.VISA_VALUE_TEMPLATE, "download"));
+
+    return Jwts.builder()
+        .header()
+        .add("jku", Strings.JWT_JKU)
+        .add("kid", Strings.JWT_KID)
+        .add("typ", Strings.JWT_TYP)
+        .add("alg", Strings.JWT_ALG)
+        .and()
+        .subject(Strings.JWT_SUBJECT)
+        .audience()
+        .add(E2EState.env.getProxyTokenAudience())
+        .and()
+        .claim("ga4gh_visa_v1", ga4ghVisa)
+        .issuer(Strings.JWT_ISSUER)
+        .expiration(new Date(Strings.JWT_EXPIRATION * 1000))
+        .issuedAt(new Date(Strings.JWT_ISSUED_AT * 1000))
+        .id(Strings.JWT_ID)
+        .signWith(attackerKeys.getPrivate(), Jwts.SIG.RS256)
+        .compact();
+  }
+}

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/AAIAspect.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/AAIAspect.java
@@ -2,6 +2,7 @@ package no.elixir.fega.ltp.aspects;
 
 import static no.elixir.fega.ltp.aspects.ProcessArgumentsAspect.ELIXIR_ID;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -72,12 +73,22 @@ public class AAIAspect {
     }
     String passportScopedAccessToken = optionalBearerAuth.get().replace("Bearer ", "");
     try {
-      String audience = tokenService.getAudience(passportScopedAccessToken);
-      if (!elixirAAIClientId.equals(audience))
-        throw new AuthenticationException(
-            String.format(
-                "Incorrect JWT audience! Expected '%s' but got '%s'", elixirAAIClientId, audience));
-      String subject = tokenService.getSubject(passportScopedAccessToken);
+      // Verify signature first. Throws on forged, expired, or malformed tokens.
+      Claims claims = tokenService.parseVerified(passportScopedAccessToken);
+
+      String audience =
+          claims.getAudience() != null && !claims.getAudience().isEmpty()
+              ? claims.getAudience().iterator().next()
+              : null;
+      if (!elixirAAIClientId.equals(audience)) {
+        throw new AuthenticationException("Invalid JWT");
+      }
+
+      String subject = claims.getSubject();
+      if (StringUtils.isEmpty(subject)) {
+        throw new AuthenticationException("JWT missing subject");
+      }
+
       String sanitizedSubject = subject.replaceAll("[\\r\\n]", "_");
       List<Visa> controlledAccessGrantsVisas =
           tokenService.getControlledAccessGrantsVisas(passportScopedAccessToken);
@@ -88,8 +99,8 @@ public class AAIAspect {
       request.setAttribute(ELIXIR_ID, subject);
       return joinPoint.proceed();
     } catch (Exception e) {
-      log.info(e.getMessage(), e);
-      return ResponseEntity.status(HttpStatus.FORBIDDEN).body(e.getMessage());
+      log.info("JWT authentication failed", e);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
   }
 

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/ExportRequestService.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/ExportRequestService.java
@@ -1,5 +1,6 @@
 package no.elixir.fega.ltp.services;
 
+import io.jsonwebtoken.Claims;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -51,7 +52,11 @@ public class ExportRequestService {
       throw new IllegalArgumentException("Access token cannot be null or empty");
     }
 
-    String subject = tokenService.getSubject(gdiExportRequestDto.getAccessToken());
+    Claims claims = tokenService.parseVerified(gdiExportRequestDto.getAccessToken());
+    String subject = claims.getSubject();
+    if (!StringUtils.hasText(subject)) {
+      throw new IllegalArgumentException("Access token missing subject");
+    }
     String sanitizedSubject = subject.replaceAll("[\r\n]", "_");
     List<Visa> controlledAccessGrantsVisas =
         tokenService.getControlledAccessGrantsVisas(gdiExportRequestDto.getAccessToken());

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/TokenService.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/TokenService.java
@@ -1,16 +1,26 @@
 package no.elixir.fega.ltp.services;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Jwk;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import no.elixir.clearinghouse.Clearinghouse;
+import no.elixir.clearinghouse.JWKProvider;
 import no.elixir.clearinghouse.model.Visa;
 import no.elixir.clearinghouse.model.VisaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import tools.jackson.databind.JsonNode;
@@ -97,49 +107,62 @@ public class TokenService {
   }
 
   /**
-   * Extracts the subject (sub) claim from the provided JWT token.
+   * Parses a passport-scoped access token and verifies its signature before returning any claims.
+   * Uses the configured PEM public key if available, otherwise falls back to JWKS discovered via
+   * the OpenID configuration URL. Throws {@link io.jsonwebtoken.JwtException} (unchecked) on
+   * signature failure, expiry, or any other validation error — callers must translate that into a
+   * rejection response.
    *
-   * <p>This method decodes the body fragment of the JWT token to retrieve the subject claim, which
-   * typically identifies the principal that issued the token.
-   *
-   * @param jwtToken the JWT token from which to extract the subject.
-   * @return the subject claim (sub) as a {@link String}.
-   * @throws NullPointerException if the JWT does not contain a subject claim.
+   * @param jwtToken passport-scoped access token.
+   * @return verified {@link Claims}.
    */
-  public String getSubject(String jwtToken) throws IllegalArgumentException {
-    JsonNode claims = extractFragmentFromJWT(jwtToken, TokenService.TokenFragment.BODY);
-    return claims.get(Claims.SUBJECT).asText();
+  public Claims parseVerified(String jwtToken) {
+    try {
+      String passportPublicKey = Files.readString(Path.of(passportPublicKeyPath));
+      RSAPublicKey key = readPEMKey(passportPublicKey);
+      return Jwts.parser().verifyWith(key).build().parseSignedClaims(jwtToken).getPayload();
+    } catch (IOException e) {
+      log.info(
+          "Passport PEM not readable ({}), falling back to OpenID JWKS for verification.",
+          e.getMessage());
+      return parseVerifiedViaJwks(jwtToken);
+    }
   }
 
-  /**
-   * Extracts the audience (aud) claim from the provided JWT token.
-   *
-   * <p>This method decodes the body fragment of the JWT token to retrieve the audience claim, which
-   * identifies the recipient for which the token is intended.
-   *
-   * @param jwtToken the JWT token from which to extract the audience.
-   * @return the audience claim (aud) as a {@link String} or null if the audience claim is missing.
-   */
-  public String getAudience(String jwtToken) throws IllegalArgumentException {
-    JsonNode claims = extractFragmentFromJWT(jwtToken, TokenService.TokenFragment.BODY);
-    JsonNode audience = claims.get(Claims.AUDIENCE);
-    if (audience == null || audience.isNull()) {
-      return null;
-    }
-    // Handle both string and array cases (JWT aud can be either)
-    String audValue;
-    if (audience.isArray()) {
-      // If it's an array, get the first element
-      if (audience.size() > 0) {
-        audValue = audience.get(0).asText();
-      } else {
-        return null; // Empty array should be treated as no audience
+  private Claims parseVerifiedViaJwks(String jwtToken) {
+    try {
+      Request request = new Request.Builder().url(openIDConfigurationURL).get().build();
+      ResponseBody body = new OkHttpClient().newCall(request).execute().body();
+      if (body == null) {
+        throw new IllegalStateException("Empty response from OpenID configuration URL");
       }
-    } else {
-      audValue = audience.asText();
+      String jwksUrl = new ObjectMapper().readTree(body.string()).get("jwks_uri").asText();
+      String kid = extractKid(jwtToken);
+      Jwk<?> jwk = JWKProvider.INSTANCE.get(jwksUrl, kid);
+      RSAPublicKey key = (RSAPublicKey) jwk.toKey();
+      return Jwts.parser().verifyWith(key).build().parseSignedClaims(jwtToken).getPayload();
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to reach OpenID JWKS endpoint", e);
     }
-    // Return null if empty string (empty string should be treated as no audience)
-    return audValue.isEmpty() ? null : audValue;
+  }
+
+  private String extractKid(String jwtToken) {
+    JsonNode header = extractFragmentFromJWT(jwtToken, TokenFragment.HEADER);
+    if (!header.has("kid")) {
+      throw new IllegalArgumentException("JWT header missing 'kid'");
+    }
+    return header.get("kid").asText();
+  }
+
+  private RSAPublicKey readPEMKey(String pem) throws IOException {
+    try {
+      String encoded = pem.replaceAll("-----(.*?)-----", "").replaceAll("\\s", "").trim();
+      byte[] decoded = Base64.getDecoder().decode(encoded);
+      return (RSAPublicKey)
+          KeyFactory.getInstance("RSA").generatePublic(new X509EncodedKeySpec(decoded));
+    } catch (GeneralSecurityException e) {
+      throw new IOException("Invalid PEM key at " + passportPublicKeyPath, e);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #789.

## Summary

- Move JWT signature verification to the proxy's auth layer instead of depending on downstream behavior.
- Close audit finding **C1** (`SECURITY-AUDIT-2026-03-27`).
- Add a negative e2e regression test to prevent regression.

## Background

`AAIAspect` read `sub`/`aud` by base64-decoding the JWT body with no signature check, then wrote the (possibly forged) subject to the request as `ELIXIR_ID`. Verification *did* happen inside `Clearinghouse.getVisaWithPublicKey`, but the resulting `SignatureException` was caught and swallowed as an empty list — the aspect never rejected on it. Forged tokens were only blocked by whatever signature check TSD happens to perform on its side, which we cannot rely on as a security boundary.

## What changed

- **`TokenService.parseVerified`** — new method. Verifies the passport-scoped access token against `/etc/ega/jwt/passport.pem` first, falling back to JWKS via the OpenID configuration URL. Throws on signature failure, expiry, or malformed tokens.
- **`AAIAspect.authenticateElixirAAI`** — rewritten to verify first, then read `sub`/`aud` from the verified `Claims` object.
- **`ExportRequestService.exportRequestGDI`** — same fix applied; the GDI export path had the same defect.
- 403 response body no longer echoes the exception message (audit **H5** — the expected audience used to leak back to the client).
- Unverified `TokenService.getSubject` / `getAudience` deleted (no remaining callers).
- `Clearinghouse` is untouched — it's a published Maven Central library; the fix belongs at the proxy boundary.

## Test

New negative regression test at `@Order(0)` in `FEGAIntegrationTest`:

- Mints a JWT signed with a freshly-generated RSA keypair the proxy does not trust.
- Sends it to `/files?inbox=true` with valid CEGA basic auth.
- Asserts HTTP 401 or 403.

Lives under a new `e2eTests/.../negative/` package, separate from the happy-path tests in `features/`. Future red-path tests land here too.

## Test plan

- [x] Proxy compiles (green locally)
- [x] ``./gradlew :e2eTests:test`` with docker stack up — legit pipeline tests still pass
- [x] C1 negative test returns 401/403 from the aspect itself (not from downstream)
- [x] Manual verification that a token signed by the real `jwt.priv.pem` is accepted (same keypair as before, same `passport.pem` used for verification)

## Adjacent findings, tracked separately

- **#790** — `Clearinghouse.getVisas*` swallows `SignatureException` and returns an empty collection. Verification failures should propagate.
- **#791** — Rework LS login token processing flow so the different token shapes are handled with typed entry points instead of string-sniff branching.
