### PR TITLE
Return status response to user in case of deleted file not found

### DIFF
--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ProxyController.java
@@ -160,7 +160,8 @@ public class ProxyController {
       throws IOException {
     Token token =
         tsdFileAPIClient.getToken(tokenType, oidcType, getElixirAAIToken(bearerAuthorization));
-    return ResponseEntity.ok(tsdFileAPIClient.deleteFile(token.getToken(), tsdAppId, fileName));
+    var deleteResponse = tsdFileAPIClient.deleteFile(token.getToken(), tsdAppId, fileName);
+    return ResponseEntity.status(deleteResponse.getStatusCode()).body(deleteResponse);
   }
 
   /**


### PR DESCRIPTION
 Previously, deleting a file from the inbox reported successful even when the requested file did not exist. Instead of always returning a 200 OK status regardless of the backend response, it now correctly propagates the HTTP status code from the delete operation.