### PR TITLE
fix(mq-interceptor): Addressing issues from the Security Audit Report

### DIFF
--- a/services/mq-interceptor/main.go
+++ b/services/mq-interceptor/main.go
@@ -317,7 +317,7 @@ func publishError(delivery amqp.Delivery, err error, errorChannel MQChannel, exc
 
 	errorMessage, jsonError := json.Marshal(message)
 	if jsonError != nil {
-		return fmt.Errorf("Unable to : %w", jsonError)
+		return fmt.Errorf("Unable to convert message to JSON: %w", jsonError)
 	}
 
 	publishing := amqp.Publishing{

--- a/services/mq-interceptor/main.go
+++ b/services/mq-interceptor/main.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -196,8 +197,8 @@ func forwardDeliveryTo(fromCEGAToLEGA bool, bridge *Bridge, routingKey string, d
 	defer publishMutex.Unlock()
 
 	channelFrom := bridge.getConsumeChannel(fromCEGAToLEGA)
-	channelTo   := bridge.getPublishChannel(fromCEGAToLEGA)
-	exchange    := bridge.getPublishExchange(fromCEGAToLEGA)
+	channelTo := bridge.getPublishChannel(fromCEGAToLEGA)
+	exchange := bridge.getPublishExchange(fromCEGAToLEGA)
 
 	publishing, messageType, err := buildPublishingFromDelivery(fromCEGAToLEGA, delivery)
 	if err != nil {
@@ -235,7 +236,7 @@ func forwardDeliveryTo(fromCEGAToLEGA bool, bridge *Bridge, routingKey string, d
 		failOnError(err, "Failed to Ack message")
 		log.Printf("Forwarded message from [%s, %s] to [%s, %s]", delivery.Exchange, delivery.RoutingKey, exchange, routingKey)
 		log.Printf("Correlation ID: %s", delivery.CorrelationId)
-		log.Printf("Message: %s", string(delivery.Body))
+		log.Printf("Message: %s", maskMessage(delivery.Body))
 	}
 }
 
@@ -257,10 +258,10 @@ func buildPublishingFromDelivery(fromCEGAToLEGA bool, delivery amqp.Delivery) (*
 		Body:            delivery.Body,
 	}
 
-	if (delivery.ContentType == "") {
+	if delivery.ContentType == "" {
 		delivery.ContentType = "application/json"
 	}
-	if (delivery.ContentType != "application/json") {
+	if delivery.ContentType != "application/json" {
 		errorMessage := fmt.Sprintf("The ContentType of the message was '%s', but it should have been 'application/json'", delivery.ContentType)
 		return &publishing, nil, validator.ValidationError{Message: errorMessage}
 	}
@@ -309,12 +310,21 @@ func buildPublishingFromDelivery(fromCEGAToLEGA bool, delivery amqp.Delivery) (*
 }
 
 func publishError(delivery amqp.Delivery, err error, errorChannel MQChannel, exchange string, routingKey string) error {
-	errorMessage := fmt.Sprintf("{\"reason\" : \"%s\", \"original_message\" : \"%s\"}", err.Error(), string(delivery.Body))
+	message := map[string]string{
+		"reason":           err.Error(),
+		"original_message": string(delivery.Body),
+	}
+
+	errorMessage, jsonError := json.Marshal(message)
+	if jsonError != nil {
+		return fmt.Errorf("Unable to : %w", jsonError)
+	}
+
 	publishing := amqp.Publishing{
 		ContentType:     delivery.ContentType,
 		ContentEncoding: delivery.ContentEncoding,
 		CorrelationId:   delivery.CorrelationId,
-		Body:            []byte(errorMessage),
+		Body:            errorMessage,
 	}
 	return errorChannel.Publish(exchange, routingKey, false, false, publishing)
 }
@@ -326,7 +336,7 @@ func postMessage(message amqp.Publishing, channel MQChannel, exchange string, ro
 func selectElixirIdByEGAId(egaId string) (elixirId string, err error) {
 	err = db.QueryRow("select elixir_id from mapping where ega_id = $1", egaId).Scan(&elixirId)
 	if err == nil {
-		log.Printf("Replacing EGA ID [%s] with Elixir ID [%s]", egaId, elixirId)
+		log.Printf("Replacing EGA ID [%s] with Elixir ID [%s]", maskEmail(egaId), maskEmail(elixirId))
 	}
 	return
 }
@@ -334,7 +344,7 @@ func selectElixirIdByEGAId(egaId string) (elixirId string, err error) {
 func selectEgaIdByElixirId(elixirId string) (egaId string, err error) {
 	err = db.QueryRow("select ega_id from mapping where elixir_id = $1", elixirId).Scan(&egaId)
 	if err == nil {
-		log.Printf("Replacing Elixir ID [%s] with EGA ID [%s]", elixirId, egaId)
+		log.Printf("Replacing Elixir ID [%s] with EGA ID [%s]", maskEmail(elixirId), maskEmail(egaId))
 	}
 	return
 }
@@ -383,5 +393,56 @@ func getTLSConfig() *tls.Config {
 func failOnError(err error, msg string) {
 	if err != nil {
 		log.Fatalf("%s: %s", msg, err)
+	}
+}
+
+func maskEmail(email string) string {
+	atIndex := strings.Index(email, "@")
+	if atIndex == -1 {
+		return email
+	}
+
+	username := email[:atIndex]
+	domain := email[atIndex+1:] // "example.com"
+
+	// Mask the username
+	masked := []byte(username)
+	if len(username) < 6 { // keep first 2 and last character. Mask the middle
+		for i := 2; i < len(username)-1; i++ {
+			masked[i] = '*'
+		}
+	} else { // keep first 3 and last 2 characters. Mask the middle
+		for i := 3; i < len(username)-2; i++ {
+			masked[i] = '*'
+		}
+	}
+
+	// Mask the full domain, except the top-level
+	lastDot := strings.LastIndex(domain, ".")
+	if lastDot == -1 {
+		return string(masked) + "@" + domain
+	}
+	tld := domain[lastDot:]
+
+	return string(masked) + "@*****" + tld
+}
+
+func maskMessage(msg []byte) string {
+	message := make(map[string]any, 0)
+	err := json.Unmarshal(msg, &message)
+	if err != nil {
+		return string(msg)
+	}
+	user, ok := message["user"].(string)
+	if ok {
+		message["user"] = maskEmail(user)
+	} else {
+		return string(msg)
+	}
+	maskedMessage, err := json.Marshal(message)
+	if err == nil {
+		return string(maskedMessage)
+	} else {
+		return string(msg)
 	}
 }

--- a/services/mq-interceptor/main_test.go
+++ b/services/mq-interceptor/main_test.go
@@ -4,8 +4,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"flag"
 	"github.com/ELIXIR-NO/FEGA-Norway/mq-interceptor/validator"
-	"io/ioutil"
+	"io"
+	"log"
 	"os"
 	"reflect"
 	"strings"
@@ -29,6 +31,8 @@ var settings = map[string]string{
 	"CEGA_MQ_QUEUE":       "v1.files",
 	"ENABLE_TLS":          "false",
 }
+
+var logOutput = flag.Bool("log-output", false, "enable log output during tests")
 
 func failTestOnError(err error, t *testing.T) {
 	if err != nil {
@@ -82,7 +86,7 @@ func readJSONmap(filename string) (map[string]any, error) {
 		return nil, err
 	}
 	defer jsonFile.Close()
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	var result map[string]any
 	json.Unmarshal([]byte(byteValue), &result)
 	return result, nil
@@ -94,7 +98,7 @@ func readJSONlist(filename string) ([]any, error) {
 		return nil, err
 	}
 	defer jsonFile.Close()
-	byteValue, _ := ioutil.ReadAll(jsonFile)
+	byteValue, _ := io.ReadAll(jsonFile)
 	var result []any
 	json.Unmarshal([]byte(byteValue), &result)
 	return result, nil
@@ -110,7 +114,13 @@ func TestMQinterceptorTests(t *testing.T) {
 
 func (testsuite *MQinterceptorTests) SetupSuite() {
 	var err error
+	if !flag.Parsed() {
+		flag.Parse()
+	}
 	t := testsuite.T()
+	if *logOutput {
+		log.SetOutput(testWriter{testsuite.T()}) // output logs from main code also
+	}
 	viper.Set("log.level", "debug")
 	t.Log("\n---------- Environment ----------")
 	for k, v := range settings {
@@ -124,6 +134,13 @@ func (testsuite *MQinterceptorTests) SetupSuite() {
 	}
 	jsonValidator = validator.NewJSONValidator("test/schemas")
 	t.Log("\n---------- Run tests ----------")
+}
+
+type testWriter struct{ t *testing.T }
+
+func (tw testWriter) Write(p []byte) (n int, err error) {
+	tw.t.Log(string(p))
+	return len(p), nil
 }
 
 func (testsuite *MQinterceptorTests) TearDownSuite() {
@@ -348,10 +365,10 @@ func (testsuite *MQinterceptorTests) Test_forwardDeliveryTo() {
 		testname := forwardTest["testname"].(string)
 		shouldFail := forwardTest["fails"].(bool)
 		queue := forwardTest["queue"].(string)
-        contentType, ok := forwardTest["contentType"].(string)
-        if !ok {
-            contentType = "application/json"
-        }
+		contentType, ok := forwardTest["contentType"].(string)
+		if !ok {
+			contentType = "application/json"
+		}
 		newuser, _ := forwardTest["enduser"].(string)
 		olduser := ""
 		cause, _ := forwardTest["cause"].(string)


### PR DESCRIPTION
This PR addresses the following concerns from the security audit report:

## H3: JSON injection
### Description
Error messages are constructed via `fmt.Sprintf` string interpolation into handcrafted JSON:

```
errorMessage := fmt.Sprintf("{\"reason\":\"%s\", \"original_message\":\"%s\"}", err.Error(), string(delivery.Body))
```

**Problem**: If `err.Error()` or `delivery.Body` contains `" ,` the JSON structure breaks or becomes injectable.
### Solution
The error message is now constructed as a map and Marshalled into JSON, as suggested.

```
message := map[string]string{
    "reason":           err.Error(),
    "original_message": string(delivery.Body),
}
errorMessage, jsonError := json.Marshal(message)
```

> [!NOTE]
> This PR does not address the second part of H3: **GDPR-sensitive data leak in mq-interceptor error messages**. "_The full message body (Elixir IDs, filepaths, checksums) is published to CEGA's error queue, which operates outside the Norwegian TSD boundary_". I don't really see the problem of including this information in error messages, since all the other messages we pass to CEGA also contain such information. The bigger question is whether we should send these error messages to CEGA at all.
>
> ... I realize now that some messages may include an Elixir ID, which is internal to our side. So, we should at least make sure all user IDs are from CEGA.

___


## H9: Full MQ message bodies logged in production
### Description
Every forwarded message body (user IDs, file paths, checksums) is logged verbatim. The EGA-to-Elixir ID mapping is explicitly printed — this mapping itself is GDPR-sensitive PII that links pseudonymous research identifiers to real identity federation accounts.

### Solution
User IDs that look like email addresses are now being masked in log output, using the same logic as our other [masking methods](https://github.com/ELIXIR-NO/FEGA-Norway/blob/cbde1380bf1c96a931499468df3d36a7d1f35356/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/common/Masker.java#L17-L28).

___


## L6: Deprecated ioutil package usage
### Description
Packge `io/ioutil` deprecated since Go 1.16. Not a vulnerability, but indicates the code hasn't been updated to current Go idioms.

### Solution
Calls to `ioutil.ReadAll(jsonFile)` are replaced with `io.ReadAll(jsonFile)`, as recommended.
