### PR TITLE
add merge-group trigger on pre-release-check.yml

### DIFF
--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -1,5 +1,6 @@
 name: Release Pre Check
 on:
+  merge_group:
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This pr adds merge-group to the triggers of  pre-release-check.yml, so it checks that all components are built successfully before merging to main.