### PR TITLE
Update lega-commander documentation and remane -b option to --direct

### DIFF
--- a/cli/lega-commander/README.md
+++ b/cli/lega-commander/README.md
@@ -120,7 +120,7 @@ lega-commander [inbox | outbox | resumables | upload | download] <args>
  upload:
   -f, --file=FILE or =FOLDER    File or folder to upload
   -r, --resume                  Resumes interrupted upload
-  -b, --beta                    Upload directly to the TSD File API through the configured TSD proxy URL, bypassing the normal Local EGA proxy streaming endpoint.
+  --direct                      Upload directly to the TSD File API through the configured TSD proxy URL, bypassing the normal Local EGA proxy streaming endpoint.
   --no-duplicate-check          Skip checking whether the file already exists in the inbox before upload.
 
  download:

--- a/cli/lega-commander/README.md
+++ b/cli/lega-commander/README.md
@@ -102,7 +102,6 @@ Table below shows how there variables must be set:
 
 ## Usage
 
-> For the time being, all of **upload** and **download** commands **should** not run with `-b` argument.
 ```
 $ lega-commander
 lega-commander [inbox | outbox | resumables | upload | download] <args>
@@ -121,7 +120,8 @@ lega-commander [inbox | outbox | resumables | upload | download] <args>
  upload:
   -f, --file=FILE or =FOLDER    File or folder to upload
   -r, --resume                  Resumes interrupted upload
-  -b, --beta                    Upload the files without the proxy service;i.e. directly to tsd file api. This means the parts of the file are sent to tsd file api instead of sending them to proxy service and then proxy service forward them to tsd file api. So it would be one-part transferring instead of two-part transferring.
+  -b, --beta                    Upload directly to the TSD File API through the configured TSD proxy URL, bypassing the normal Local EGA proxy streaming endpoint.
+  --no-duplicate-check          Skip checking whether the file already exists in the inbox before upload.
 
  download:
   -f, --file= FILE or =FOLDER   File or folder to download
@@ -145,6 +145,16 @@ that contains c4gh files, we can use this example command:
 ```
 lega-commander upload  -f /path/to/a/folder/containing/c4gh/files
 ```
+### Skipping the duplicate-file check
+
+By default, lega-commander checks whether a file with the same name already exists in the inbox before uploading.
+
+For large inboxes, this check can be slow because it requires listing existing inbox files. If you are sure that the file does not already exist, you can skip this check with `--no-duplicate-check`:
+
+```
+lega-commander upload -f /path/to/a/c4gh/file/sample-c4gh-file.c4gh --no-duplicate-check
+```
+Be aware that existing files with the same name may be overwritten if the duplicate check is skipped.
 
 <!--
 ### How it works

--- a/cli/lega-commander/main.go
+++ b/cli/lega-commander/main.go
@@ -62,7 +62,7 @@ var resumablesOptionsParser = flags.NewParser(&resumablesOptions, flags.None)
 var uploadingOptions struct {
 	FileName         string `short:"f"  long:"file" description:"File or folder to upload" value-name:"FILE" required:"true"`
 	Resume           bool   `short:"r" long:"resume" description:"Resumes interrupted upload"`
-	Straight         bool   `short:"b" long:"beta" description:"Upload the files without the proxy service;i.e. directly to tsd file api"`
+	Straight         bool   `long:"direct" description:"Upload the files without the proxy service;i.e. directly to tsd file api"`
 	NoDuplicateCheck bool   `long:"no-duplicate-check" description:"Skip checking whether the file already exists in the inbox before upload"`
 }
 
@@ -70,7 +70,7 @@ var uploadingOptionsParser = flags.NewParser(&uploadingOptions, flags.None)
 
 var downloadingOptions struct {
 	FileName string `short:"f"  long:"file" description:"File to download\t[optional]"`
-	Straight bool   `short:"b" long:"beta" description:"download the files without the proxy service;i.e. directly from tsd file api"`
+	Straight bool   `long:"direct" description:"download the files without the proxy service;i.e. directly from tsd file api"`
 }
 
 var downloadingOptionsParser = flags.NewParser(&downloadingOptions, flags.None)


### PR DESCRIPTION
Changes include:
- Remove the outdated warning about avoiding `-b`.
- Change `-b` / `--beta` to `--direct`and improve description.
- Document the `--no-duplicate-check` upload option.