### PR TITLE
feat: add JSON schema validation for export requests

### DIFF
--- a/services/localega-tsd-proxy/README.md
+++ b/services/localega-tsd-proxy/README.md
@@ -57,6 +57,14 @@ spring.data.redis:
   database: ${REDIS_DB:0}
 ```
 
+### JSON Schema Configuration
+
+The export request JSON schema can be overridden by setting the following environment variable:
+
+```yaml
+json.schema.export-request.location: ${EXPORT_REQUEST_SCHEMA_LOCATION:classpath:export-request.json}
+```
+
 ### RabbitMQ Configuration
 
 ```yaml

--- a/services/localega-tsd-proxy/build.gradle.kts
+++ b/services/localega-tsd-proxy/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.13.0")
     implementation("org.springframework.boot:spring-boot-starter-security-oauth2-resource-server")
     implementation("com.github.ben-manes.caffeine:caffeine:3.2.4")
+    implementation("com.networknt:json-schema-validator:3.0.2")
+    implementation("org.graalvm.js:js:25.0.3")
     testImplementation("com.squareup.okhttp3:mockwebserver:5.3.2")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.amqp:spring-rabbit-test")

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ExportRequestController.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/controllers/rest/ExportRequestController.java
@@ -5,6 +5,7 @@ import no.elixir.fega.ltp.dto.FegaExportRequestDto;
 import no.elixir.fega.ltp.dto.GdiExportRequestDto;
 import no.elixir.fega.ltp.dto.GenericResponse;
 import no.elixir.fega.ltp.exceptions.GenericException;
+import no.elixir.fega.ltp.exceptions.JsonSchemaValidationException;
 import no.elixir.fega.ltp.services.ExportRequestService;
 import org.springframework.amqp.AmqpException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +37,10 @@ public class ExportRequestController {
     } catch (GenericException e) {
       log.error("Export request failed for user: {}", e.getMessage(), e);
       return ResponseEntity.status(e.getHttpStatus()).body(new GenericResponse(e.getMessage()));
+    } catch (JsonSchemaValidationException e) {
+      log.error("Export request message failed schema validation: {}", e.getMessage(), e);
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body(new GenericResponse(e.getMessage()));
     } catch (IllegalArgumentException e) {
       log.error("Invalid export request: {}", e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.BAD_REQUEST)
@@ -56,6 +61,10 @@ public class ExportRequestController {
     } catch (GenericException e) {
       log.error("FEGA export request failed: {}", e.getMessage(), e);
       return ResponseEntity.status(e.getHttpStatus()).body(new GenericResponse(e.getMessage()));
+    } catch (JsonSchemaValidationException e) {
+      log.error("FEGA export request message failed schema validation: {}", e.getMessage(), e);
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+          .body(new GenericResponse(e.getMessage()));
     } catch (IllegalArgumentException e) {
       log.error("Invalid FEGA export request: {}", e.getMessage(), e);
       return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/exceptions/JsonSchemaValidationException.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/exceptions/JsonSchemaValidationException.java
@@ -1,0 +1,7 @@
+package no.elixir.fega.ltp.exceptions;
+
+public class JsonSchemaValidationException extends RuntimeException {
+  public JsonSchemaValidationException(String message) {
+    super(message);
+  }
+}

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/models/DOAExportRequest.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/models/DOAExportRequest.java
@@ -1,5 +1,6 @@
 package no.elixir.fega.ltp.models;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,6 +14,7 @@ import no.elixir.fega.ltp.dto.GdiExportRequestDto;
 @ToString
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class DOAExportRequest {
 
   @JsonProperty("jwtToken")

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/ExportRequestService.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/ExportRequestService.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Service
@@ -28,6 +30,8 @@ public class ExportRequestService {
 
   private final TokenService tokenService;
   private final RabbitTemplate tsdRabbitTemplate;
+  private final JsonSchemaValidationService jsonSchemaValidationService;
+  private final ObjectMapper objectMapper;
 
   @Value("${mq.tsd.exchange}")
   private String exchange;
@@ -36,9 +40,15 @@ public class ExportRequestService {
   private String routingKey;
 
   @Autowired
-  public ExportRequestService(TokenService tokenService, RabbitTemplate tsdRabbitTemplate) {
+  public ExportRequestService(
+      TokenService tokenService,
+      RabbitTemplate tsdRabbitTemplate,
+      JsonSchemaValidationService jsonSchemaValidationService,
+      ObjectMapper objectMapper) {
     this.tokenService = tokenService;
     this.tsdRabbitTemplate = tsdRabbitTemplate;
+    this.jsonSchemaValidationService = jsonSchemaValidationService;
+    this.objectMapper = objectMapper;
   }
 
   public void exportRequestGDI(GdiExportRequestDto gdiExportRequestDto)
@@ -128,6 +138,11 @@ public class ExportRequestService {
   }
 
   private void sendToRabbitMQ(DOAExportRequest message) throws AmqpException {
+    try {
+      jsonSchemaValidationService.validate(objectMapper.writeValueAsString(message));
+    } catch (JacksonException e) {
+      throw new IllegalStateException("Failed to serialize export request message", e);
+    }
     tsdRabbitTemplate.convertAndSend(
         exchange,
         routingKey,

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/JsonSchemaValidationService.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/services/JsonSchemaValidationService.java
@@ -1,0 +1,50 @@
+package no.elixir.fega.ltp.services;
+
+import com.networknt.schema.*;
+import com.networknt.schema.Error;
+import com.networknt.schema.regex.GraalJSRegularExpressionFactory;
+import java.util.stream.Collectors;
+import no.elixir.fega.ltp.exceptions.JsonSchemaValidationException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JsonSchemaValidationService {
+
+  private final Schema schema;
+
+  public JsonSchemaValidationService(
+      @Value("${json.schema.export-request.location:classpath:export-request.json}")
+          String schemaLocation) {
+    try {
+      SchemaRegistryConfig schemaRegistryConfig =
+          SchemaRegistryConfig.builder()
+              .regularExpressionFactory(GraalJSRegularExpressionFactory.getInstance())
+              .build();
+
+      SchemaRegistry schemaRegistry =
+          SchemaRegistry.withDefaultDialect(
+              SpecificationVersion.DRAFT_7,
+              builder -> builder.schemaRegistryConfig(schemaRegistryConfig));
+
+      this.schema = schemaRegistry.getSchema(SchemaLocation.of(schemaLocation));
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          "Failed to load JSON schema from location '" + schemaLocation + "'", e);
+    }
+  }
+
+  public void validate(String jsonContent) throws JsonSchemaValidationException {
+    var errors =
+        schema.validate(
+            jsonContent,
+            InputFormat.JSON,
+            ctx -> ctx.executionConfig(c -> c.formatAssertionsEnabled(true)));
+
+    if (!errors.isEmpty()) {
+      String errorMessage =
+          errors.stream().map(Error::getMessage).collect(Collectors.joining("\n"));
+      throw new JsonSchemaValidationException("JSON Schema Validation Failed: " + errorMessage);
+    }
+  }
+}

--- a/services/localega-tsd-proxy/src/main/resources/application.yaml
+++ b/services/localega-tsd-proxy/src/main/resources/application.yaml
@@ -119,3 +119,11 @@ jwk-cache:
   duration: 60
   time-unit: minutes
   max-size: 100
+
+json:
+  schema:
+    export-request:
+      # Location of the JSON schema used to validate export request messages.
+      # Supports Spring resource prefixes: classpath:, file:, http(s):, etc.
+      # In Docker/production, override with e.g. file:/etc/ega/schemas/export-request.json
+      location: ${JSON_SCHEMA_EXPORT_REQUEST_LOCATION:classpath:export-request.json}

--- a/services/localega-tsd-proxy/src/main/resources/export-request.json
+++ b/services/localega-tsd-proxy/src/main/resources/export-request.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/neicnordic/sensitive-data-archive/tree/main/sda-doa/src/main/resources/export-request.json",
+  "title": "Export Request Message",
+  "description": "Validation schema for sensitive data export requests via RabbitMQ.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "jwtToken",
+    "publicKey"
+  ],
+  "anyOf": [
+    { "required": ["datasetId"] },
+    { "required": ["fileId"] }
+  ],
+  "properties": {
+    "jwtToken": {
+      "type": "string",
+      "description": "The JWT bearer token for authorization.",
+      "pattern": "^[A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]*$"
+    },
+    "datasetId": {
+      "type": "string",
+      "description": "Unique identifier for the dataset.",
+      "minLength": 1
+    },
+    "fileId": {
+      "type": "string",
+      "description": "Unique identifier for the specific file.",
+      "minLength": 1
+    },
+    "publicKey": {
+      "type": "string",
+      "description": "The encryption public key in Crypt4GH or PEM format.",
+      "minLength": 20
+    },
+    "startCoordinate": {
+      "type": "string",
+      "description": "The starting byte offset for the export.",
+      "pattern": "^[0-9]+$"
+    },
+    "endCoordinate": {
+      "type": "string",
+      "description": "The ending byte offset for the export.",
+      "pattern": "^[0-9]+$"
+    }
+  }
+}

--- a/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/services/JsonSchemaValidationServiceTest.java
+++ b/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/services/JsonSchemaValidationServiceTest.java
@@ -1,0 +1,292 @@
+package no.elixir.fega.ltp.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import no.elixir.fega.ltp.exceptions.JsonSchemaValidationException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JsonSchemaValidationServiceTest {
+
+  // A syntactically valid JWT (header.payload.signature, all base64url characters)
+  private static final String VALID_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.c2lnbmF0dXJl";
+
+  // Meets publicKey minLength: 20
+  private static final String VALID_PUBLIC_KEY = "AABBCCDDEEFFGGHHIIJJ";
+
+  private JsonSchemaValidationService service;
+
+  @BeforeAll
+  void setUp() {
+    service = new JsonSchemaValidationService("classpath:export-request.json");
+  }
+
+  @Test
+  void validate_doesNotThrow_whenOnlyDatasetIdProvided() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertDoesNotThrow(() -> service.validate(message));
+  }
+
+  @Test
+  void validate_doesNotThrow_whenOnlyFileIdProvided() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "fileId": "EGAF00000000014",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertDoesNotThrow(() -> service.validate(message));
+  }
+
+  @Test
+  void validate_doesNotThrow_whenBothDatasetIdAndFileIdProvided() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919",
+                  "fileId": "EGAF00000000014",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertDoesNotThrow(() -> service.validate(message));
+  }
+
+  @Test
+  void validate_doesNotThrow_withOptionalCoordinates() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "%s",
+                  "startCoordinate": "100",
+                  "endCoordinate": "200"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertDoesNotThrow(() -> service.validate(message));
+  }
+
+  @Test
+  void validate_doesNotThrow_whenCoordinateIsZero() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "fileId": "EGAF00000000014",
+                  "publicKey": "%s",
+                  "startCoordinate": "0"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertDoesNotThrow(() -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenJwtTokenIsMissing() {
+    String message =
+        """
+                {
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_PUBLIC_KEY);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenPublicKeyIsMissing() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919"
+                }
+                """
+            .formatted(VALID_JWT);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenNeitherDatasetIdNorFileIdIsPresent() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenJsonObjectIsEmpty() {
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate("{}"));
+  }
+
+  @Test
+  void validate_throws_whenJwtTokenDoesNotMatchPattern() {
+    String message =
+        """
+                {
+                  "jwtToken": "not-a-valid-jwt",
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_PUBLIC_KEY);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenDatasetIdIsEmpty() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenFileIdIsEmpty() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "fileId": "",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenPublicKeyIsTooShort() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "tooshort"
+                }
+                """
+            .formatted(VALID_JWT);
+
+    // "tooshort" is 8 chars, below minLength: 20
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenStartCoordinateIsNotNumeric() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "%s",
+                  "startCoordinate": "not-a-number"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenEndCoordinateIsNegative() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "%s",
+                  "endCoordinate": "-100"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    // Negative numbers have a leading "-", which does not match pattern ^[0-9]+$
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_throws_whenAdditionalPropertyIsPresent() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "datasetId": "EGAD00010000919",
+                  "publicKey": "%s",
+                  "unknownField": "value"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+  }
+
+  @Test
+  void validate_exceptionMessage_includesValidationFailedPrefix() {
+    String message =
+        """
+                {
+                  "jwtToken": "%s",
+                  "publicKey": "%s"
+                }
+                """
+            .formatted(VALID_JWT, VALID_PUBLIC_KEY);
+
+    JsonSchemaValidationException ex =
+        assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+    assertTrue(
+        ex.getMessage().startsWith("JSON Schema Validation Failed:"),
+        "Expected message to start with 'JSON Schema Validation Failed:', got: " + ex.getMessage());
+  }
+
+  @Test
+  void validate_exceptionMessage_includesAllViolations_whenMultipleConstraintsFail() {
+    String message = "{}";
+
+    JsonSchemaValidationException ex =
+        assertThrows(JsonSchemaValidationException.class, () -> service.validate(message));
+    // Multiple required fields are missing; the message should contain more than one error line
+    long violationCount = ex.getMessage().lines().count();
+    assertTrue(violationCount > 1, "Expected multiple violation lines, got: " + violationCount);
+  }
+}


### PR DESCRIPTION
- Implemented JSON schema validation using `json-schema-validator` and integrated it into the export request flow.
- Added `JsonSchemaValidationService` for schema validation.
- Extended `ExportRequestService` to validate export request messages.
- Created unit tests for schema validation.
- Updated application properties to support JSON schema configuration.