### PR TITLE
feat(e2e): SDA V2 upgrade + proxy-anonymized inbox-path handling

### DIFF
--- a/e2eTests/confs/sda/config.yaml
+++ b/e2eTests/confs/sda/config.yaml
@@ -1,0 +1,15 @@
+c4gh:
+  privateKeys:
+    - filePath: <<SDA_C4GH_FILEPATH>>
+      passphrase: <<SDA_C4GH_PASSPHRASE>>
+
+storage:
+  inbox:
+    posix:
+      - path: <<SDA_INBOX_LOCATION>>
+    # FEGA-Norway stores the full project-code inbox path (p11-<user>/files/...)
+    # verbatim, so ingest and mapper must not re-apply the username transform.
+    useSubmissionPathVerbatim: true
+  archive:
+    posix:
+      - path: <<SDA_ARCHIVE_LOCATION>>

--- a/e2eTests/confs/sda/config.yaml
+++ b/e2eTests/confs/sda/config.yaml
@@ -7,9 +7,11 @@ storage:
   inbox:
     posix:
       - path: <<SDA_INBOX_LOCATION>>
-    # FEGA-Norway stores the full project-code inbox path (p11-<user>/files/...)
-    # verbatim, so ingest and mapper must not re-apply the username transform.
-    useSubmissionPathVerbatim: true
+    # SDA rebuilds the physical inbox dir "p11-<user>/files/..." from the anonymized submission
+    # path + the message user. TSD keeps the raw "@", so normalizeUsername is false. See #820.
+    projectCode: p11
+    projectCodeDelimiter: "-"
+    normalizeUsername: false
   archive:
     posix:
       - path: <<SDA_ARCHIVE_LOCATION>>

--- a/e2eTests/confs/sda/config.yaml
+++ b/e2eTests/confs/sda/config.yaml
@@ -8,10 +8,10 @@ storage:
     posix:
       - path: <<SDA_INBOX_LOCATION>>
     # SDA rebuilds the physical inbox dir "p11-<user>/files/..." from the anonymized submission
-    # path + the message user. TSD keeps the raw "@", so normalizeUsername is false. See #820.
+    # path + the message user. A configured project code stores the raw username (TSD keeps the
+    # "@"), so normalization is off by derivation — no separate toggle. See #820.
     projectCode: p11
     projectCodeDelimiter: "-"
-    normalizeUsername: false
   archive:
     posix:
       - path: <<SDA_ARCHIVE_LOCATION>>

--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -174,7 +174,7 @@ services:
   db:
     container_name: db
     hostname: db
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47-postgres
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-postgres
     ports:
       - "5432:5432"
     environment:
@@ -201,7 +201,9 @@ services:
   ingest:
     container_name: ingest
     hostname: ingest
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    # Custom image: stock v3.1.61 + the gated verbatim inbox-path resolver.
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-norway
+    pull_policy: never
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -213,8 +215,6 @@ services:
       - mq
       - db
     environment:
-      - ARCHIVE_TYPE=<<SDA_ARCHIVE_TYPE>>
-      - ARCHIVE_LOCATION=<<SDA_ARCHIVE_LOCATION>>
       - BROKER_HOST=<<SDA_BROKER_HOST>>
       - BROKER_PORT=<<SDA_BROKER_PORT>>
       - BROKER_USER=<<SDA_BROKER_USER>>
@@ -229,8 +229,6 @@ services:
       - BROKER_CACERT=<<SDA_BROKER_CACERT>>
       - BROKER_CLIENTCERT=<<SDA_BROKER_CLIENTCERT>>
       - BROKER_CLIENTKEY=<<SDA_BROKER_CLIENTKEY>>
-      - C4GH_PASSPHRASE=<<SDA_C4GH_PASSPHRASE>>
-      - C4GH_FILEPATH=<<SDA_C4GH_FILEPATH>>
       - DB_HOST=<<SDA_DB_HOST>>
       - DB_PORT=<<SDA_DB_PORT>>
       - DB_USER=<<SDA_DB_USER>>
@@ -239,20 +237,20 @@ services:
       - DB_SSLMODE=<<SDA_DB_SSLMODE>>
       - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
       - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
-      - INBOX_TYPE=<<SDA_INBOX_TYPE>>
-      - INBOX_LOCATION=<<SDA_INBOX_LOCATION>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
+      - CONFIGFILE=/sda-config/config.yaml
     volumes:
       - tsd-inbox:/ega/inbox/
       - tsd-vault:/ega/archive/
       - sda-certs:/etc/ega/
       - db-client-certs:/db-client-certs
+      - sda-config:/sda-config
     command: "sda-ingest"
 
   verify:
     container_name: verify
     hostname: verify
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -264,8 +262,6 @@ services:
       - mq
       - db
     environment:
-      - ARCHIVE_TYPE=<<SDA_ARCHIVE_TYPE>>
-      - ARCHIVE_LOCATION=<<SDA_ARCHIVE_LOCATION>>
       - BROKER_HOST=<<SDA_BROKER_HOST>>
       - BROKER_PORT=<<SDA_BROKER_PORT>>
       - BROKER_USER=<<SDA_BROKER_USER>>
@@ -280,8 +276,6 @@ services:
       - BROKER_CACERT=<<SDA_BROKER_CACERT>>
       - BROKER_CLIENTCERT=<<SDA_BROKER_CLIENTCERT>>
       - BROKER_CLIENTKEY=<<SDA_BROKER_CLIENTKEY>>
-      - C4GH_PASSPHRASE=<<SDA_C4GH_PASSPHRASE>>
-      - C4GH_FILEPATH=<<SDA_C4GH_FILEPATH>>
       - DB_HOST=<<SDA_DB_HOST>>
       - DB_PORT=<<SDA_DB_PORT>>
       - DB_USER=<<SDA_DB_USER>>
@@ -290,19 +284,20 @@ services:
       - DB_SSLMODE=<<SDA_DB_SSLMODE>>
       - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
       - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
-      - INBOX_LOCATION=<<SDA_INBOX_LOCATION>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
+      - CONFIGFILE=/sda-config/config.yaml
     volumes:
       - tsd-inbox:/ega/inbox/
       - tsd-vault:/ega/archive/
       - sda-certs:/etc/ega/
       - db-client-certs:/db-client-certs
+      - sda-config:/sda-config
     command: "sda-verify"
 
   finalize:
     container_name: finalize
     hostname: finalize
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -345,7 +340,9 @@ services:
   mapper:
     container_name: mapper
     hostname: mapper
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    # Custom image: stock v3.1.61 + the gated verbatim inbox-path resolver.
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-norway
+    pull_policy: never
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -379,17 +376,18 @@ services:
       - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
       - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
-      - INBOX_LOCATION=<<SDA_INBOX_LOCATION>>
+      - CONFIGFILE=/sda-config/config.yaml
     volumes:
       - tsd-inbox:/ega/inbox
       - sda-certs:/etc/ega/
       - db-client-certs:/db-client-certs
+      - sda-config:/sda-config
     command: "sda-mapper"
 
   intercept:
     container_name: intercept
     hostname: intercept
-    image: ghcr.io/neicnordic/sensitive-data-archive:v0.3.47
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -438,7 +436,7 @@ services:
   doa:
     container_name: doa
     hostname: doa
-    image: ghcr.io/neicnordic/sensitive-data-archive:v1.0.18-doa
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-doa
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -637,6 +635,7 @@ services:
       - cegamq-certs:/volumes/cegamq-certs
       - cegamq-confs:/volumes/cegamq-confs
       - heartbeat-confs:/volumes/heartbeat-confs
+      - sda-config:/volumes/sda-config
       - storage:/storage
     healthcheck:
       test: [ "CMD", "sh", "-c", "[ -f /storage/ready ]" ]  # Check for the ready file
@@ -713,4 +712,5 @@ volumes:
   cegamq-certs:
   cegamq-confs:
   heartbeat-confs:
+  sda-config:
   storage:

--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -8,6 +8,9 @@ services:
     container_name: tsd
     hostname: tsd
     image: tsd-api-mock:latest
+    # Run as the SDA service uid (65534) so inbox files the mock writes are owned by
+    # 65534, letting the mapper (also 65534) delete them after mapping.
+    user: "65534:65534"
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -692,6 +695,8 @@ services:
       # - E2E_TESTS_EGA_DEV_ARCHIVE_PUB_KEYPATH=
     volumes:
       - storage:/storage
+      # read-only inbox so the suite can assert the mapper removed the uploaded file
+      - tsd-inbox:/ega/inbox:ro
 
 volumes:
   tsd-inbox:

--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -204,7 +204,7 @@ services:
   ingest:
     container_name: ingest
     hostname: ingest
-    # Custom image: stock v3.1.61 + the gated verbatim inbox-path resolver.
+    # Custom image: stock v3.1.61 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
     image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-norway
     pull_policy: never
     depends_on:
@@ -343,7 +343,7 @@ services:
   mapper:
     container_name: mapper
     hostname: mapper
-    # Custom image: stock v3.1.61 + the gated verbatim inbox-path resolver.
+    # Custom image: stock v3.1.61 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
     image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-norway
     pull_policy: never
     depends_on:

--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -177,7 +177,7 @@ services:
   db:
     container_name: db
     hostname: db
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-postgres
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-postgres
     ports:
       - "5432:5432"
     environment:
@@ -204,8 +204,8 @@ services:
   ingest:
     container_name: ingest
     hostname: ingest
-    # Custom image: stock v3.1.61 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-norway
+    # Custom image: stock v3.1.72 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-norway
     pull_policy: never
     depends_on:
       file-orchestrator:
@@ -229,19 +229,22 @@ services:
       - BROKER_ROUTINGERROR=<<SDA_BROKER_ROUTINGERROR>>
       - BROKER_SSL=<<SDA_BROKER_SSL>>
       - BROKER_VERIFYPEER=<<SDA_BROKER_VERIFYPEER>>
-      - BROKER_CACERT=<<SDA_BROKER_CACERT>>
-      - BROKER_CLIENTCERT=<<SDA_BROKER_CLIENTCERT>>
-      - BROKER_CLIENTKEY=<<SDA_BROKER_CLIENTKEY>>
-      - DB_HOST=<<SDA_DB_HOST>>
-      - DB_PORT=<<SDA_DB_PORT>>
-      - DB_USER=<<SDA_DB_USER>>
-      - DB_PASSWORD=<<SDA_DB_PASSWORD>>
-      - DB_DATABASE=<<SDA_DB_DATABASE>>
-      - DB_SSLMODE=<<SDA_DB_SSLMODE>>
-      - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
-      - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
+      - BROKER_CA_CERT=<<SDA_BROKER_CACERT>>
+      - BROKER_CLIENT_CERT=<<SDA_BROKER_CLIENTCERT>>
+      - BROKER_CLIENT_KEY=<<SDA_BROKER_CLIENTKEY>>
+      - DATABASE_HOST=<<SDA_DB_HOST>>
+      - DATABASE_PORT=<<SDA_DB_PORT>>
+      - DATABASE_USER=<<SDA_DB_USER>>
+      - DATABASE_PASSWORD=<<SDA_DB_PASSWORD>>
+      - DATABASE_NAME=<<SDA_DB_DATABASE>>
+      - DATABASE_SSL_MODE=<<SDA_DB_SSLMODE>>
+      - DATABASE_CLIENT_CERT=<<SDA_DB_CLIENTCERT>>
+      - DATABASE_CLIENT_KEY=<<SDA_DB_CLIENTKEY>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
       - CONFIGFILE=/sda-config/config.yaml
+      # v3.1.72 ingest loads config through config/v2, which reads the config file from
+      # CONFIG_FILE / config-path rather than the legacy CONFIGFILE.
+      - CONFIG_FILE=/sda-config/config.yaml
     volumes:
       - tsd-inbox:/ega/inbox/
       - tsd-vault:/ega/archive/
@@ -253,7 +256,7 @@ services:
   verify:
     container_name: verify
     hostname: verify
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -279,14 +282,14 @@ services:
       - BROKER_CACERT=<<SDA_BROKER_CACERT>>
       - BROKER_CLIENTCERT=<<SDA_BROKER_CLIENTCERT>>
       - BROKER_CLIENTKEY=<<SDA_BROKER_CLIENTKEY>>
-      - DB_HOST=<<SDA_DB_HOST>>
-      - DB_PORT=<<SDA_DB_PORT>>
-      - DB_USER=<<SDA_DB_USER>>
-      - DB_PASSWORD=<<SDA_DB_PASSWORD>>
-      - DB_DATABASE=<<SDA_DB_DATABASE>>
-      - DB_SSLMODE=<<SDA_DB_SSLMODE>>
-      - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
-      - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
+      - DATABASE_HOST=<<SDA_DB_HOST>>
+      - DATABASE_PORT=<<SDA_DB_PORT>>
+      - DATABASE_USER=<<SDA_DB_USER>>
+      - DATABASE_PASSWORD=<<SDA_DB_PASSWORD>>
+      - DATABASE_NAME=<<SDA_DB_DATABASE>>
+      - DATABASE_SSL_MODE=<<SDA_DB_SSLMODE>>
+      - DATABASE_CLIENT_CERT=<<SDA_DB_CLIENTCERT>>
+      - DATABASE_CLIENT_KEY=<<SDA_DB_CLIENTKEY>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
       - CONFIGFILE=/sda-config/config.yaml
     volumes:
@@ -300,7 +303,7 @@ services:
   finalize:
     container_name: finalize
     hostname: finalize
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -326,14 +329,14 @@ services:
       - BROKER_CACERT=<<SDA_BROKER_CACERT>>
       - BROKER_CLIENTCERT=<<SDA_BROKER_CLIENTCERT>>
       - BROKER_CLIENTKEY=<<SDA_BROKER_CLIENTKEY>>
-      - DB_HOST=<<SDA_DB_HOST>>
-      - DB_PORT=<<SDA_DB_PORT>>
-      - DB_USER=<<SDA_DB_USER>>
-      - DB_PASSWORD=<<SDA_DB_PASSWORD>>
-      - DB_DATABASE=<<SDA_DB_DATABASE>>
-      - DB_SSLMODE=<<SDA_DB_SSLMODE>>
-      - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
-      - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
+      - DATABASE_HOST=<<SDA_DB_HOST>>
+      - DATABASE_PORT=<<SDA_DB_PORT>>
+      - DATABASE_USER=<<SDA_DB_USER>>
+      - DATABASE_PASSWORD=<<SDA_DB_PASSWORD>>
+      - DATABASE_NAME=<<SDA_DB_DATABASE>>
+      - DATABASE_SSL_MODE=<<SDA_DB_SSLMODE>>
+      - DATABASE_CLIENT_CERT=<<SDA_DB_CLIENTCERT>>
+      - DATABASE_CLIENT_KEY=<<SDA_DB_CLIENTKEY>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
     command: "sda-finalize"
     volumes:
@@ -343,8 +346,8 @@ services:
   mapper:
     container_name: mapper
     hostname: mapper
-    # Custom image: stock v3.1.61 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-norway
+    # Custom image: stock v3.1.72 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-norway
     pull_policy: never
     depends_on:
       file-orchestrator:
@@ -370,14 +373,14 @@ services:
       - BROKER_CACERT=<<SDA_BROKER_CACERT>>
       - BROKER_CLIENTCERT=<<SDA_BROKER_CLIENTCERT>>
       - BROKER_CLIENTKEY=<<SDA_BROKER_CLIENTKEY>>
-      - DB_HOST=<<SDA_DB_HOST>>
-      - DB_PORT=<<SDA_DB_PORT>>
-      - DB_USER=<<SDA_DB_USER>>
-      - DB_PASSWORD=<<SDA_DB_PASSWORD>>
-      - DB_DATABASE=<<SDA_DB_DATABASE>>
-      - DB_SSLMODE=<<SDA_DB_SSLMODE>>
-      - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
-      - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
+      - DATABASE_HOST=<<SDA_DB_HOST>>
+      - DATABASE_PORT=<<SDA_DB_PORT>>
+      - DATABASE_USER=<<SDA_DB_USER>>
+      - DATABASE_PASSWORD=<<SDA_DB_PASSWORD>>
+      - DATABASE_NAME=<<SDA_DB_DATABASE>>
+      - DATABASE_SSL_MODE=<<SDA_DB_SSLMODE>>
+      - DATABASE_CLIENT_CERT=<<SDA_DB_CLIENTCERT>>
+      - DATABASE_CLIENT_KEY=<<SDA_DB_CLIENTKEY>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
       - CONFIGFILE=/sda-config/config.yaml
     volumes:
@@ -390,7 +393,7 @@ services:
   intercept:
     container_name: intercept
     hostname: intercept
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -412,14 +415,14 @@ services:
       - BROKER_CACERT=<<SDA_BROKER_CACERT>>
       - BROKER_CLIENTCERT=<<SDA_BROKER_CLIENTCERT>>
       - BROKER_CLIENTKEY=<<SDA_BROKER_CLIENTKEY>>
-      - DB_HOST=<<SDA_DB_HOST>>
-      - DB_PORT=<<SDA_DB_PORT>>
-      - DB_USER=<<SDA_DB_USER>>
-      - DB_PASSWORD=<<SDA_DB_PASSWORD>>
-      - DB_DATABASE=<<SDA_DB_DATABASE>>
-      - DB_SSLMODE=<<SDA_DB_SSLMODE>>
-      - DB_CLIENTCERT=<<SDA_DB_CLIENTCERT>>
-      - DB_CLIENTKEY=<<SDA_DB_CLIENTKEY>>
+      - DATABASE_HOST=<<SDA_DB_HOST>>
+      - DATABASE_PORT=<<SDA_DB_PORT>>
+      - DATABASE_USER=<<SDA_DB_USER>>
+      - DATABASE_PASSWORD=<<SDA_DB_PASSWORD>>
+      - DATABASE_NAME=<<SDA_DB_DATABASE>>
+      - DATABASE_SSL_MODE=<<SDA_DB_SSLMODE>>
+      - DATABASE_CLIENT_CERT=<<SDA_DB_CLIENTCERT>>
+      - DATABASE_CLIENT_KEY=<<SDA_DB_CLIENTKEY>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
     links:
       - mq
@@ -439,7 +442,7 @@ services:
   doa:
     container_name: doa
     hostname: doa
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.61-doa
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-doa
     depends_on:
       file-orchestrator:
         condition: service_healthy

--- a/e2eTests/docker-compose.template.yml
+++ b/e2eTests/docker-compose.template.yml
@@ -177,7 +177,7 @@ services:
   db:
     container_name: db
     hostname: db
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-postgres
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.73-postgres
     ports:
       - "5432:5432"
     environment:
@@ -204,9 +204,8 @@ services:
   ingest:
     container_name: ingest
     hostname: ingest
-    # Custom image: stock v3.1.72 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-norway
-    pull_policy: never
+    # Stock image: the projectCode inbox-path resolver shipped in v3.1.73 (neicnordic#2466).
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.73
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -242,7 +241,7 @@ services:
       - DATABASE_CLIENT_KEY=<<SDA_DB_CLIENTKEY>>
       - LOG_LEVEL=<<SDA_LOG_LEVEL>>
       - CONFIGFILE=/sda-config/config.yaml
-      # v3.1.72 ingest loads config through config/v2, which reads the config file from
+      # v3.1.73 ingest loads config through config/v2, which reads the config file from
       # CONFIG_FILE / config-path rather than the legacy CONFIGFILE.
       - CONFIG_FILE=/sda-config/config.yaml
     volumes:
@@ -256,7 +255,7 @@ services:
   verify:
     container_name: verify
     hostname: verify
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.73
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -303,7 +302,7 @@ services:
   finalize:
     container_name: finalize
     hostname: finalize
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.73
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -346,9 +345,8 @@ services:
   mapper:
     container_name: mapper
     hostname: mapper
-    # Custom image: stock v3.1.72 + the projectCode inbox-path resolver (helper.ResolveInboxPath / InboxConfig, see ELIXIR-NO/FEGA-Norway#820).
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-norway
-    pull_policy: never
+    # Stock image: the projectCode inbox-path resolver shipped in v3.1.73 (neicnordic#2466).
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.73
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -393,7 +391,7 @@ services:
   intercept:
     container_name: intercept
     hostname: intercept
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.73
     depends_on:
       file-orchestrator:
         condition: service_healthy
@@ -442,7 +440,7 @@ services:
   doa:
     container_name: doa
     hostname: doa
-    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.72-doa
+    image: ghcr.io/neicnordic/sensitive-data-archive:v3.1.73-doa
     depends_on:
       file-orchestrator:
         condition: service_healthy

--- a/e2eTests/scripts/change_ownerships.sh
+++ b/e2eTests/scripts/change_ownerships.sh
@@ -5,6 +5,9 @@ cd confs || exit 1
 # tsd
 chmod 777 /volumes/tsd-outbox/*
 chown -R 65534:65534 /volumes/tsd-outbox/*
+# The tsd mock now runs as uid 65534 (same as the SDA services), so the inbox it
+# writes is owned by 65534 and the mapper can delete files from it after mapping.
+chown -R 65534:65534 /volumes/tsd-inbox/
 
 # proxy
 chmod -R 777 /volumes/proxy-certs/*

--- a/e2eTests/scripts/change_ownerships.sh
+++ b/e2eTests/scripts/change_ownerships.sh
@@ -70,6 +70,14 @@ echo "Inspecting /volumes/doa-certs/"
 ls -alh /volumes/doa-certs/
 echo
 
+# sda-config (read by the SDA pipeline services running as uid 65534)
+chmod -R 644 /volumes/sda-config/
+chown -R 65534:65534 /volumes/sda-config/
+chmod 755 /volumes/sda-config/
+echo "Inspecting /volumes/sda-config/"
+ls -alh /volumes/sda-config/
+echo
+
 cd .. # Go back to the working directory.
 
 echo "Done modifying the file ownerships to match expected uid:gid(s) ✅"

--- a/e2eTests/scripts/change_ownerships.sh
+++ b/e2eTests/scripts/change_ownerships.sh
@@ -76,9 +76,11 @@ ls -alh /volumes/doa-certs/
 echo
 
 # sda-config (read by the SDA pipeline services running as uid 65534)
-chmod -R 644 /volumes/sda-config/
+# Set dirs and files separately so directories keep +x (traversable) at any nesting depth;
+# a blanket `chmod -R 644` would strip execute from subdirectories. See FEGA-Norway#819 review.
 chown -R 65534:65534 /volumes/sda-config/
-chmod 755 /volumes/sda-config/
+find /volumes/sda-config/ -type d -exec chmod 755 {} \;
+find /volumes/sda-config/ -type f -exec chmod 644 {} \;
 echo "Inspecting /volumes/sda-config/"
 ls -alh /volumes/sda-config/
 echo

--- a/e2eTests/scripts/change_ownerships.sh
+++ b/e2eTests/scripts/change_ownerships.sh
@@ -66,6 +66,8 @@ echo
 chmod -R 777 /volumes/doa-certs/
 chown -R 65534:65534 /volumes/doa-certs/
 chmod 755 /volumes/doa-certs/
+# pgJDBC's PEMKeyManager rejects a DB client key readable by group/other; lock it to owner-only.
+chmod 600 /volumes/doa-certs/ssl/client.key
 echo "Inspecting /volumes/doa-certs/"
 ls -alh /volumes/doa-certs/
 echo

--- a/e2eTests/scripts/copy_certificates_to_dest.sh
+++ b/e2eTests/scripts/copy_certificates_to_dest.sh
@@ -61,7 +61,7 @@ mkdir -p /volumes/doa-certs/ssl/ /volumes/doa-certs/jwt/ /volumes/doa-certs/cryp
   cp rootCA.pem /volumes/doa-certs/ssl/CA.cert &&
   cp server.p12 /volumes/doa-certs/ssl/server.p12 &&
   cp client.pem /volumes/doa-certs/ssl/client.cert &&
-  cp client-key.der /volumes/doa-certs/ssl/client.key &&
+  cp client-key.pem /volumes/doa-certs/ssl/client.key &&
   cp jwt.pub.pem /volumes/doa-certs/jwt/passport.pem &&
   cp jwt.pub.pem /volumes/doa-certs/jwt/visa.pem &&
   cp ega.sec.pem /volumes/doa-certs/crypt4gh/key.pem &&

--- a/e2eTests/scripts/copy_confs_to_dest.sh
+++ b/e2eTests/scripts/copy_confs_to_dest.sh
@@ -14,3 +14,6 @@ cp -R ./postgres/* /volumes/postgres-confs/
 
 # cegamq
 cp -R ./cegamq/* /volumes/cegamq-confs
+
+# sda pipeline
+cp -R ./sda/* /volumes/sda-config

--- a/e2eTests/scripts/replace_template_variables.sh
+++ b/e2eTests/scripts/replace_template_variables.sh
@@ -23,4 +23,11 @@ frepl "<<MQ_SSL_VERIFY>>" "$MQ_SSL_VERIFY" $rabbitmq_conf_file
 frepl "<<MQ_SSL_FAIL_IF_NO_PEER_CERT>>" "$MQ_SSL_FAIL_IF_NO_PEER_CERT" $rabbitmq_conf_file
 frepl "<<MQ_SSL_DEPTH>>" "$MQ_SSL_DEPTH" $rabbitmq_conf_file
 
+ # sda pipeline
+sda_config_file=/volumes/sda-config/config.yaml
+frepl "<<SDA_C4GH_FILEPATH>>" "$SDA_C4GH_FILEPATH" $sda_config_file
+frepl "<<SDA_C4GH_PASSPHRASE>>" "$SDA_C4GH_PASSPHRASE" $sda_config_file
+frepl "<<SDA_INBOX_LOCATION>>" "$SDA_INBOX_LOCATION" $sda_config_file
+frepl "<<SDA_ARCHIVE_LOCATION>>" "$SDA_ARCHIVE_LOCATION" $sda_config_file
+
 echo "Replaced all the template variables using .env ✅"

--- a/e2eTests/src/test/java/no/elixir/e2eTests/FEGAIntegrationTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/FEGAIntegrationTest.java
@@ -67,7 +67,7 @@ public class FEGAIntegrationTest {
 
   @Test
   @Order(6)
-  void InboxCleanupTest() {
+  void InboxCleanupTest() throws Exception {
     // The mapper removes the inbox file after mapping; this is the only assertion
     // that exercises that cleanup (no DB signal records it).
     InboxCleanupTest.verifyInboxFileRemovedAfterMapping();

--- a/e2eTests/src/test/java/no/elixir/e2eTests/FEGAIntegrationTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/FEGAIntegrationTest.java
@@ -67,6 +67,14 @@ public class FEGAIntegrationTest {
 
   @Test
   @Order(6)
+  void InboxCleanupTest() {
+    // The mapper removes the inbox file after mapping; this is the only assertion
+    // that exercises that cleanup (no DB signal records it).
+    InboxCleanupTest.verifyInboxFileRemovedAfterMapping();
+  }
+
+  @Test
+  @Order(7)
   void ReleaseTest() throws Exception {
     ReleaseTest.triggerReleaseMessageFromCEGA();
     // Wait for LEGA mapper service to update dataset status
@@ -74,7 +82,7 @@ public class FEGAIntegrationTest {
   }
 
   @Test
-  @Order(7)
+  @Order(8)
   void DownloadTest() throws Exception {
     DownloadTest.downloadDatasetAndVerifyResults();
   }

--- a/e2eTests/src/test/java/no/elixir/e2eTests/constants/Strings.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/constants/Strings.java
@@ -30,7 +30,7 @@ public class Strings {
               {
                 "type": "ingest",
                 "user": "%s",
-                "filepath": "/%s-%s/files/%s"
+                "filepath": "/files/%s"
               }
             """;
 
@@ -39,7 +39,7 @@ public class Strings {
             {
                 "type": "accession",
                 "user": "%s",
-                "filepath": "/%s-%s/files/%s",
+                "filepath": "/files/%s",
                 "accession_id": "%s",
                 "decrypted_checksums": [
                     {

--- a/e2eTests/src/test/java/no/elixir/e2eTests/features/AccessionTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/features/AccessionTest.java
@@ -41,8 +41,6 @@ public class AccessionTest {
         String.format(
             Strings.ACCESSION_MESSAGE,
             E2EState.env.getCegaAuthUsername(),
-            E2EState.env.getTsdProject(),
-            E2EState.env.getLsaaiSubject(),
             E2EState.encFile.getName(),
             randomFileAccessionID,
             E2EState.rawSHA256Checksum,

--- a/e2eTests/src/test/java/no/elixir/e2eTests/features/FinalizeTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/features/FinalizeTest.java
@@ -37,10 +37,9 @@ public class FinalizeTest {
     String sql =
         "select archive_path,stable_id from local_ega.files where status = 'READY' AND inbox_path = ?";
     PreparedStatement statement = conn.prepareStatement(sql);
-    String tsdProject = E2EState.env.getTsdProject();
-    String subject = E2EState.env.getLsaaiSubject();
-    statement.setString(
-        1, "/%s-%s/files/%s".formatted(tsdProject, subject, E2EState.encFile.getName()));
+    // The DB stores the anonymized submission path; SDA reconstructs the physical
+    // p11-<user>/files/ path on access. See ELIXIR-NO/FEGA-Norway#820.
+    statement.setString(1, "/files/%s".formatted(E2EState.encFile.getName()));
     ResultSet resultSet = statement.executeQuery();
     if (resultSet.wasNull() || !resultSet.next()) {
       fail("Verification failed");

--- a/e2eTests/src/test/java/no/elixir/e2eTests/features/InboxCleanupTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/features/InboxCleanupTest.java
@@ -1,44 +1,80 @@
 package no.elixir.e2eTests.features;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import java.io.File;
+import java.util.Collection;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
 import no.elixir.e2eTests.core.E2EState;
 import no.elixir.e2eTests.utils.CommonUtils;
+import no.elixir.e2eTests.utils.TokenUtils;
 
 public class InboxCleanupTest {
 
-  // The inbox volume is mounted read-only into the e2e-tests container at the same
-  // path the SDA services see it.
-  private static final String INBOX_ROOT = "/ega/inbox";
-
   /**
-   * After mapping a file to a dataset, the mapper removes the uploaded file from the inbox. Nothing
-   * in the DB records that removal, so without this check a mapper that silently fails to delete
-   * (e.g. wrong path or a permission error) would still let the suite pass. Poll until the file is
-   * gone and fail if it never is.
+   * After mapping a file to a dataset, the SDA mapper removes the uploaded file from the inbox.
+   * Nothing in the DB records that removal, so without this check a mapper that silently fails to
+   * delete (wrong path, permission error) would still let the suite pass. We observe the inbox over
+   * the network via the proxy's {@code GET /files?inbox=true} listing (the same endpoint the
+   * outbox/export flow uses, flipped to the inbox), so the assertion holds whether the suite runs
+   * in-container or as a jar against a host stack. Poll until the file is gone and fail if it never
+   * is.
+   *
+   * <p>Inbox listing requires both the LS-AAI bearer (Proxy-Authorization) and CEGA basic auth, the
+   * same pair the upload sends; only the outbox listing is exempt from CEGA auth. The bearer is
+   * resolved exactly as the upload does ({@link no.elixir.e2eTests.features.UploadViaLegaCMDTest}):
+   * a real LS-AAI token in EGA_DEV runs, else a minted visa token. Both carry the same subject, so
+   * they map to the same inbox dir.
    */
-  public static void verifyInboxFileRemovedAfterMapping() {
-    String tsdProject = E2EState.env.getTsdProject();
-    // The physical inbox dir is <projectCode>-<LS-AAI subject> (e.g. p11-dummy@elixir-europe.org).
-    // It matches what the mapper deletes only because the mq-interceptor maps the CEGA user to
-    // exactly this LS-AAI subject, which SDA reconstructs via ResolveInboxPath. See
-    // FEGA-Norway#820.
-    String subject = E2EState.env.getLsaaiSubject();
-    File inboxFile =
-        new File(
-            INBOX_ROOT,
-            "%s-%s/files/%s".formatted(tsdProject, subject, E2EState.encFile.getName()));
-    E2EState.log.info("Verifying mapper removed the inbox file: {}", inboxFile.getAbsolutePath());
+  public static void verifyInboxFileRemovedAfterMapping() throws Exception {
+    String fileName = E2EState.encFile.getName();
+    String token = resolveListingToken();
+    String listUrl =
+        "https://%s:%s/files?inbox=true"
+            .formatted(E2EState.env.getProxyHost(), E2EState.env.getProxyPort());
+    E2EState.log.info("Verifying mapper removed '{}' from the inbox via {}", fileName, listUrl);
 
-    int attempts = 20;
-    while (inboxFile.exists() && attempts-- > 0) {
-      CommonUtils.waitForProcessing(1000);
+    int attempts = E2EState.env.getExportRequestMaxRetries();
+    int intervalMillis = (int) (E2EState.env.getExportRequestIntervalInSeconds() * 1000);
+    boolean present = true;
+    for (int i = 1; i <= attempts; i++) {
+      HttpResponse<FileListingResponse> res =
+          Unirest.get(listUrl)
+              .header("Proxy-Authorization", "Bearer " + token)
+              .basicAuth(E2EState.env.getCegaAuthUsername(), E2EState.env.getCegaAuthPassword())
+              .asObject(FileListingResponse.class);
+      assertEquals(200, res.getStatus(), "inbox listing request failed: " + res.getStatus());
+
+      present = res.getBody().files().stream().anyMatch(f -> fileName.equals(f.fileName()));
+      if (!present) {
+        E2EState.log.info("Inbox cleanup verified: '{}' gone after {} attempt(s)", fileName, i);
+        break;
+      }
+      E2EState.log.info("'{}' still present in inbox, attempt {}/{}", fileName, i, attempts);
+      CommonUtils.waitForProcessing(intervalMillis);
     }
 
-    assertFalse(
-        inboxFile.exists(),
-        "Mapper did not remove the uploaded file from the inbox: " + inboxFile.getAbsolutePath());
-    E2EState.log.info("Inbox cleanup verified: mapper removed the file");
+    assertFalse(present, "Mapper did not remove the uploaded file from the inbox: " + fileName);
   }
+
+  private static String resolveListingToken() throws Exception {
+    String provided = E2EState.env.getLSAAIToken();
+    if (provided == null || provided.isEmpty()) {
+      return TokenUtils.generateVisaToken("upload", "jwt.pub.pem", "jwt.priv.pem");
+    }
+    return provided;
+  }
+
+  record FileListingResponse(Collection<TsdFile> files, String page) {}
+
+  record TsdFile(
+      String fileName,
+      Long size,
+      String modifiedDate,
+      String href,
+      Boolean exportable,
+      String reason,
+      String mimeType,
+      String owner) {}
 }

--- a/e2eTests/src/test/java/no/elixir/e2eTests/features/InboxCleanupTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/features/InboxCleanupTest.java
@@ -20,10 +20,15 @@ public class InboxCleanupTest {
    */
   public static void verifyInboxFileRemovedAfterMapping() {
     String tsdProject = E2EState.env.getTsdProject();
+    // The physical inbox dir is <projectCode>-<LS-AAI subject> (e.g. p11-dummy@elixir-europe.org).
+    // It matches what the mapper deletes only because the mq-interceptor maps the CEGA user to
+    // exactly this LS-AAI subject, which SDA reconstructs via ResolveInboxPath. See
+    // FEGA-Norway#820.
     String subject = E2EState.env.getLsaaiSubject();
     File inboxFile =
         new File(
-            INBOX_ROOT, "%s-%s/files/%s".formatted(tsdProject, subject, E2EState.encFile.getName()));
+            INBOX_ROOT,
+            "%s-%s/files/%s".formatted(tsdProject, subject, E2EState.encFile.getName()));
     E2EState.log.info("Verifying mapper removed the inbox file: {}", inboxFile.getAbsolutePath());
 
     int attempts = 20;

--- a/e2eTests/src/test/java/no/elixir/e2eTests/features/InboxCleanupTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/features/InboxCleanupTest.java
@@ -1,0 +1,39 @@
+package no.elixir.e2eTests.features;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.io.File;
+import no.elixir.e2eTests.core.E2EState;
+import no.elixir.e2eTests.utils.CommonUtils;
+
+public class InboxCleanupTest {
+
+  // The inbox volume is mounted read-only into the e2e-tests container at the same
+  // path the SDA services see it.
+  private static final String INBOX_ROOT = "/ega/inbox";
+
+  /**
+   * After mapping a file to a dataset, the mapper removes the uploaded file from the inbox. Nothing
+   * in the DB records that removal, so without this check a mapper that silently fails to delete
+   * (e.g. wrong path or a permission error) would still let the suite pass. Poll until the file is
+   * gone and fail if it never is.
+   */
+  public static void verifyInboxFileRemovedAfterMapping() {
+    String tsdProject = E2EState.env.getTsdProject();
+    String subject = E2EState.env.getLsaaiSubject();
+    File inboxFile =
+        new File(
+            INBOX_ROOT, "%s-%s/files/%s".formatted(tsdProject, subject, E2EState.encFile.getName()));
+    E2EState.log.info("Verifying mapper removed the inbox file: {}", inboxFile.getAbsolutePath());
+
+    int attempts = 20;
+    while (inboxFile.exists() && attempts-- > 0) {
+      CommonUtils.waitForProcessing(1000);
+    }
+
+    assertFalse(
+        inboxFile.exists(),
+        "Mapper did not remove the uploaded file from the inbox: " + inboxFile.getAbsolutePath());
+    E2EState.log.info("Inbox cleanup verified: mapper removed the file");
+  }
+}

--- a/e2eTests/src/test/java/no/elixir/e2eTests/features/IngestTest.java
+++ b/e2eTests/src/test/java/no/elixir/e2eTests/features/IngestTest.java
@@ -38,11 +38,10 @@ public class IngestTest {
             .build();
 
     String message =
+        // Anonymized path: just the filename under /files/. SDA rebuilds the project-code path
+        // from the (interceptor-mapped) user. See FEGA-Norway#820.
         Strings.INGEST_MESSAGE.formatted(
-            E2EState.env.getCegaAuthUsername(),
-            E2EState.env.getTsdProject(),
-            E2EState.env.getLsaaiSubject(),
-            E2EState.encFile.getName());
+            E2EState.env.getCegaAuthUsername(), E2EState.encFile.getName());
     E2EState.log.info(message);
     channel.basicPublish("localega", "files", properties, message.getBytes());
     channel.close();

--- a/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
+++ b/services/localega-tsd-proxy/src/main/java/no/elixir/fega/ltp/aspects/PublishMQAspect.java
@@ -30,9 +30,6 @@ public class PublishMQAspect {
 
   private final RabbitTemplate tsdRabbitTemplate;
 
-  @Value("${tsd.project}")
-  private String tsdProjectId;
-
   @Value("${tsd.inbox-path-format}")
   private String inboxPathFormat;
 
@@ -207,19 +204,16 @@ public class PublishMQAspect {
   }
 
   /**
-   * Builds the user-specific relative inbox path by formatting the inbox path format string with
-   * the TSD project ID and the Elixir user ID, then appending the filename. The resulting path
-   * follows the pattern: {@code /<tsd-project-id>-<elixir-user-id>/files/<fileName>}.
+   * Builds the anonymized inbox path published in the MQ message: the configured inbox prefix
+   * followed by the filename (e.g. {@code /files/<fileName>}). The project code and username are
+   * deliberately omitted — SDA reconstructs the physical {@code p11-<user>/files/...} path from the
+   * message's user field and its own inbox configuration. See ELIXIR-NO/FEGA-Norway#820.
    *
-   * @param fileName the name of the file to append to the inbox path.
-   * @return the fully constructed inbox path for the given file.
+   * @param fileName the name of the file to append to the inbox prefix.
+   * @return the anonymized inbox path for the given file.
    */
   private String buildInboxPath(String fileName) {
-    Object elixirId = request.getAttribute(ELIXIR_ID);
-    if (elixirId == null) {
-      throw new IllegalStateException("ELIXIR_ID request attribute is not set");
-    }
-    return String.format(inboxPathFormat, tsdProjectId, elixirId.toString()) + fileName;
+    return inboxPathFormat + fileName;
   }
 
   private void publishMessage(FileDescriptor fileDescriptor, String type) {

--- a/services/localega-tsd-proxy/src/main/resources/application.yaml
+++ b/services/localega-tsd-proxy/src/main/resources/application.yaml
@@ -77,8 +77,10 @@ tsd:
   app-id: ${TSD_APP_ID:ega}
   app-out-id: ${TSD_APP_OUT_ID:egaout}
   access-key: ${TSD_ACCESS_KEY}
-  # Format: /<tsd-project-id>-<elixir-user-id>/files/ — the trailing slash is required because the filename is appended at the end.
-  inbox-path-format: ${TSD_INBOX_PATH_FORMAT:/%s-%s/files/}
+  # Anonymized inbox prefix published in the MQ message; the filename is appended (trailing slash
+  # required). SDA reconstructs the physical p11-<user>/files/ path from the message user + its own
+  # inbox config — see ELIXIR-NO/FEGA-Norway#820.
+  inbox-path-format: ${TSD_INBOX_PATH_FORMAT:/files/}
   root-ca: ${TSD_ROOT_CERT_PATH:/etc/ega/ssl/CA.cert}
   root-ca-password: ${TSD_ROOT_CERT_PASSWORD:}
 

--- a/services/tsd-api-mock/src/main/java/no/elixir/tsdapimock/core/resumables/Resumables.java
+++ b/services/tsd-api-mock/src/main/java/no/elixir/tsdapimock/core/resumables/Resumables.java
@@ -186,18 +186,14 @@ public class Resumables {
   }
 
   /**
-   * Lists files in the specified outbox/export directory after checking if it exists and contains
-   * files Creates the directory if it doesn't exist.
+   * Lists the files in the given directory, creating it first when {@code createIfNotExists} is
+   * set.
    *
-   * @param project the project parameter
-   * @param userName the username parameter
+   * @param dirPath the absolute directory to list
    * @param createIfNotExists whether to create the directory if it doesn't exist
-   * @return List of file names, or empty list if directory doesn't exist or is empty
+   * @return the files in the directory, or an empty list if it doesn't exist or is empty
    */
-  public List<File> listFiles(String project, String userName, boolean createIfNotExists) {
-    // Construct the directory path
-    String dirPath = tsdElixirExport.formatted(project, userName);
-
+  private List<File> listFilesInDirectory(String dirPath, boolean createIfNotExists) {
     // Create File object for the directory
     File directory = new File(dirPath);
 
@@ -236,5 +232,15 @@ public class Resumables {
 
     log.info("Found {} files in: {}", files.length, dirPath);
     return List.of(files);
+  }
+
+  /** Lists the files in the user's outbox (export) directory. */
+  public List<File> listFiles(String project, String userName, boolean createIfNotExists) {
+    return listFilesInDirectory(tsdElixirExport.formatted(project, userName), createIfNotExists);
+  }
+
+  /** Lists the files in the user's inbox (import) directory. */
+  public List<File> listInboxFiles(String project, String userName, boolean createIfNotExists) {
+    return listFilesInDirectory(tsdElixirImport.formatted(project, userName), createIfNotExists);
   }
 }

--- a/services/tsd-api-mock/src/main/java/no/elixir/tsdapimock/endpoints/ega/EgaFilesController.java
+++ b/services/tsd-api-mock/src/main/java/no/elixir/tsdapimock/endpoints/ega/EgaFilesController.java
@@ -33,6 +33,23 @@ public class EgaFilesController {
     }
   }
 
+  @GetMapping(value = "/files", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> getFiles(
+      @PathVariable String project,
+      @PathVariable String userName,
+      @RequestHeader("Authorization") String authorizationHeader) {
+    try {
+      var response = egaFilesService.listInboxFiles(authorizationHeader, project, userName);
+      return ResponseEntity.status(HttpStatus.OK)
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(response);
+    } catch (CredentialsMismatchException e) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(e.getMessage());
+    } catch (IllegalArgumentException e) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());
+    }
+  }
+
   @PatchMapping(
       value = "/files/{fileName}",
       consumes = MediaType.APPLICATION_OCTET_STREAM_VALUE,

--- a/services/tsd-api-mock/src/main/java/no/elixir/tsdapimock/endpoints/ega/EgaFilesService.java
+++ b/services/tsd-api-mock/src/main/java/no/elixir/tsdapimock/endpoints/ega/EgaFilesService.java
@@ -1,17 +1,28 @@
 package no.elixir.tsdapimock.endpoints.ega;
 
+import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import no.elixir.tsdapimock.core.exceptions.CredentialsMismatchException;
 import no.elixir.tsdapimock.core.exceptions.FileProcessingException;
 import no.elixir.tsdapimock.core.resumables.*;
 import no.elixir.tsdapimock.core.utils.JwtService;
+import no.elixir.tsdapimock.endpoints.egaout.dto.OutboxFileListingDto;
+import no.elixir.tsdapimock.endpoints.egaout.dto.TSDFileDto;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 public class EgaFilesService {
 
@@ -84,5 +95,65 @@ public class EgaFilesService {
     }
 
     return Resumables.convertToDto(uploadedResumable);
+  }
+
+  public OutboxFileListingDto listInboxFiles(
+      String authorizationHeader, String project, String userName) {
+    if (!authorizationHeader.startsWith("Bearer ")) {
+      throw new IllegalArgumentException("Header must contain a bearer auth token");
+    }
+    if (!jwtService.verify(authorizationHeader)) {
+      throw new CredentialsMismatchException("Stream processing failed");
+    }
+    boolean createUserDirectoryIfNotExists = false;
+    List<File> files = resumables.listInboxFiles(project, userName, createUserDirectoryIfNotExists);
+
+    List<TSDFileDto> tsdFiles = new ArrayList<>();
+    for (File file : files) {
+      if (file.isFile()) {
+        tsdFiles.add(createTSDFileDtoFromFile(file, userName));
+      }
+    }
+
+    final String PAGE_NUMBER = "1";
+    return new OutboxFileListingDto(tsdFiles, PAGE_NUMBER);
+  }
+
+  /** Creates a TSDFileDto record from a File object. */
+  private static TSDFileDto createTSDFileDtoFromFile(File file, String owner) {
+    try {
+      Path path = file.toPath();
+      BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
+
+      DateTimeFormatter formatter =
+          DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+      String modifiedDate = formatter.format(attrs.lastModifiedTime().toInstant());
+
+      String mimeType = Files.probeContentType(path);
+      if (mimeType == null) {
+        mimeType = "application/octet-stream";
+      }
+
+      return new TSDFileDto(
+          file.getName(),
+          file.length(),
+          modifiedDate,
+          "/files/" + file.getName(),
+          true,
+          null,
+          mimeType,
+          owner);
+    } catch (Exception e) {
+      log.error("Error reading file attributes for: {}", file.getName(), e);
+      return new TSDFileDto(
+          file.getName(),
+          file.length(),
+          "Unknown",
+          "/files/" + file.getName(),
+          false,
+          "Error reading file attributes",
+          "application/octet-stream",
+          owner);
+    }
   }
 }


### PR DESCRIPTION
## What

Upgraded the FEGA-Norway e2e stack from the old SDA `v0.3.47` (v1) images to **SDA V2 (`v3.1.73`)** and got the full pipeline green end-to-end with our project-code inbox layout.

## Inbox-path handling (the core)

The proxy now **anonymizes** the path it publishes to CEGA, `filepath: /files/<file>` with the project code and username stripped (`PublishMQAspect` + `application.yaml`), so the TSD layout never leaks into the federation. SDA then **reconstructs** the physical `p11-<user>/files/...` path from config (companion SDA PR neicnordic#2466). The e2e config sets `storage.inbox.{projectCode: p11, projectCodeDelimiter: "-"}`; normalization is derived from the project code, so there is no separate toggle. The `mq-interceptor` stays a pass-through (it maps the *user identity*, not the path). Decision record + rationale: **#820**.

## Other changes

- **config/v2 migration**: on `v3.1.73` the V2 services load through `config/v2`, so the e2e env keys were renamed (`DB_*` -> `DATABASE_*`, `BROKER_CACERT` -> `BROKER_CA_CERT`, `CONFIGFILE` -> `CONFIG_FILE`) and the now-defunct `normalizeUsername` key dropped. Services read storage + c4gh from a mounted `config.yaml`; all SDA images are now stock `v3.1.73` (db `-postgres`, doa `-doa`). The projectCode resolver plus the non-s3inbox ingest fix (SDA neicnordic#2466, regression neicnordic#2467) shipped in stock `v3.1.73`, so ingest/mapper no longer need the earlier local `v3.1.72-norway` build.
- **DOA DB client key**: `v3.1.73-doa`'s pgJDBC `PEMKeyManager` needs a PKCS#8 **PEM** key at **600**; switched off the DER key and fixed perms. (Prod uses one-way TLS to the DB, so this mutual-TLS key is e2e-only.)
- **tsd mock runs as 65534**: it wrote inbox files as root, so the mapper (65534) couldn't delete them; running it as 65534 makes ownership uniform.
- **Inbox-cleanup check, now network-based**: `InboxCleanupTest` asserts the mapper actually removed the inbox file (the suite previously stayed green even when it silently failed to delete). It now verifies this over the network through the proxy's `GET /files?inbox=true` listing instead of reading the container's inbox bind-mount, so the assertion holds whether the suite runs in-container or as a jar against a host stack. That required adding the inbox file-listing endpoint to `tsd-api-mock` (`GET /v1/{project}/ega/{user}/files`), which previously implemented only the outbox listing (real TSD lists both).
- **sda-config perms**: set directories and files separately so directories stay traversable (review comment).

## Verification

All 9 `FEGAIntegrationTest` tests pass end-to-end: upload -> ingest -> verify -> finalize -> mapping -> **inbox-cleanup** -> release -> download. A file walks `registered -> archived -> verified -> ready`, accession and dataset mapped, download served. (Green on the `v3.1.72` + #2466 images; re-run on stock `v3.1.73` is the next step now that #2466 is released.)
