### PR TITLE
fix(mq-interceptor): Add JSON schema mapping for "cancel" messages

### DIFF
--- a/services/mq-interceptor/test/tests.json
+++ b/services/mq-interceptor/test/tests.json
@@ -213,4 +213,23 @@
     "enduser"    : "alice@elixir.org",
     "message"    : "This is just a regular text"
   }
+ ,
+  {
+    "testname"   : "test cancel",
+    "description": [
+                     "Test cancel-message sent from CEGA to LEGA.",
+                     "The message is validated against the same schema as ingest-messages, i.e. 'ingestion-trigger.json'.",
+                     "The user name should be replaced, and the message should end up in the 'files' queue in LEGA."
+                   ],
+    "direction"  : "lega",
+    "queue"      : "files",
+    "fails"      : false,
+    "enduser"    : "alice@elixir.org",
+    "message"    : {
+                     "type": "cancel",
+                     "user": "alice@ega.org",
+                     "filepath": "/inbox/user/dir1/file.txt.c4gh",
+                     "encrypted_checksums": [ { "type": "sha256", "value": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" } ]
+                   }
+  }
 ]

--- a/services/mq-interceptor/validator/json_validator.go
+++ b/services/mq-interceptor/validator/json_validator.go
@@ -12,6 +12,7 @@ import (
 // mapping between message "type" and JSON schema file (excluding suffix)
 var schemaMapping = map[string]string{
 	"accession":          "ingestion-accession",
+	"cancel":             "ingestion-trigger",
 	"contact.updated":    "user-contact-updated",
 	"dac":                "dac-information",
 	"dac.dataset":        "dac-dataset-mapping",


### PR DESCRIPTION
Adds missing JSON schema mapping for "cancel" messages.

Cancel messages are validated against the same schema as "ingest", i.e. `ingestion-trigger.json`, where the value of the type-field can be either "ingest" or "cancel" ([as seen here](https://github.com/ELIXIR-NO/FEGA-Norway/blob/c1be05dcd14ae0013b82132d20d29918a9bb54c8/services/mq-interceptor/test/schemas/ingestion-trigger.json#L87-L95))