### PR TITLE
test(localega-tsd-proxy): assert forged tokens are rejected on the upload path (C1)

### DIFF
--- a/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/aspects/AAIAspectTest.java
+++ b/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/aspects/AAIAspectTest.java
@@ -1,0 +1,66 @@
+package no.elixir.fega.ltp.aspects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.http.HttpServletRequest;
+import no.elixir.fega.ltp.authentication.CEGACredentialsProvider;
+import no.elixir.fega.ltp.services.TokenService;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+class AAIAspectTest {
+
+  private HttpServletRequest request;
+  private TokenService tokenService;
+  private ProceedingJoinPoint joinPoint;
+  private AAIAspect aspect;
+
+  @BeforeEach
+  void setUp() {
+    request = mock(HttpServletRequest.class);
+    tokenService = mock(TokenService.class);
+    joinPoint = mock(ProceedingJoinPoint.class);
+    aspect =
+        new AAIAspect(request, mock(CEGACredentialsProvider.class), tokenService, "test-client-id");
+  }
+
+  /**
+   * Audit control C1, response half: when token verification refuses a token, the request must end
+   * as 403 and the proxied call must never run. Guards the catch block that turns a verifier
+   * exception into a response; a refactor that swallows the exception and proceeds goes red here.
+   */
+  @Test
+  void authenticateElixirAAI_returns403WithoutProceeding_whenVerificationFails() throws Throwable {
+    when(request.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn("Bearer forged-token");
+    when(tokenService.parseVerified(anyString()))
+        .thenThrow(new SignatureException("JWT signature does not match"));
+
+    Object response = aspect.authenticateElixirAAI(joinPoint);
+
+    assertThat(response).isInstanceOf(ResponseEntity.class);
+    assertThat(((ResponseEntity<?>) response).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    verify(tokenService).parseVerified("forged-token");
+    verify(joinPoint, never()).proceed();
+  }
+
+  @Test
+  void authenticateElixirAAI_returns401WithoutProceeding_whenTokenMissing() throws Throwable {
+    when(request.getHeader(HttpHeaders.PROXY_AUTHORIZATION)).thenReturn(null);
+
+    Object response = aspect.authenticateElixirAAI(joinPoint);
+
+    assertThat(response).isInstanceOf(ResponseEntity.class);
+    assertThat(((ResponseEntity<?>) response).getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    verify(joinPoint, never()).proceed();
+  }
+}

--- a/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/config/JwtDecoderConfigTest.java
+++ b/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/config/JwtDecoderConfigTest.java
@@ -1,12 +1,20 @@
 package no.elixir.fega.ltp.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import java.io.IOException;
+import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.interfaces.RSAPublicKey;
+import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
@@ -14,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 
 class JwtDecoderConfigTest {
@@ -73,5 +82,32 @@ class JwtDecoderConfigTest {
 
     // 7. Verify the cache object itself is not empty
     assertThat(jwkCache.getNativeCache()).isNotNull();
+  }
+
+  @Test
+  void jwtDecoder_rejectsTokenSignedByUntrustedKey() throws Exception {
+    // The oauth2 resource-server endpoints (/token, /user) trust this decoder, built here
+    // through the production JwtDecoderConfig wiring rather than a hand-rolled one. The
+    // forged token reuses the served key's id ("test-key") but is signed with a different,
+    // untrusted key, so the decoder resolves a key and the failure is specifically a
+    // signature mismatch, not a missing key. The upload path (Proxy-Authorization) has its
+    // own guard in TokenServiceTest and AAIAspectTest.
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(2048);
+    KeyPair untrusted = kpg.generateKeyPair();
+
+    SignedJWT forged =
+        new SignedJWT(
+            new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("test-key").build(),
+            new JWTClaimsSet.Builder().subject("attacker").build());
+    forged.sign(new RSASSASigner(untrusted.getPrivate()));
+
+    String aaiBase = mockWebServer.url("").toString().replaceAll("/$", "");
+    JwtDecoder jwtDecoder = new JwtDecoderConfig(10, 5, TimeUnit.MINUTES, aaiBase).jwtDecoder();
+    mockWebServer.enqueue(
+        new MockResponse().setBody(mockJwkSetJson).setHeader("Content-Type", "application/json"));
+
+    assertThatThrownBy(() -> jwtDecoder.decode(forged.serialize()))
+        .isInstanceOf(JwtException.class);
   }
 }

--- a/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/services/TokenServiceTest.java
+++ b/services/localega-tsd-proxy/src/test/java/no/elixir/fega/ltp/services/TokenServiceTest.java
@@ -1,0 +1,92 @@
+package no.elixir.fega.ltp.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SignatureException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TokenServiceTest {
+
+  @TempDir Path tempDir;
+
+  private TokenService tokenService;
+  private KeyPair trusted;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    trusted = generateRsaKeyPair();
+
+    // A readable PEM keeps parseVerified on the static-key branch; an unreadable path
+    // would silently fall back to network JWKS discovery and break test isolation.
+    Path pem = tempDir.resolve("passport-public-key.pem");
+    Files.writeString(
+        pem,
+        "-----BEGIN PUBLIC KEY-----\n"
+            + Base64.getMimeEncoder().encodeToString(trusted.getPublic().getEncoded())
+            + "\n-----END PUBLIC KEY-----\n");
+
+    tokenService = new TokenService();
+    ReflectionTestUtils.setField(tokenService, "passportPublicKeyPath", pem.toString());
+  }
+
+  /**
+   * Audit control C1: a structurally valid, unexpired token signed by a key outside the trusted key
+   * set must be refused. Every claim is valid, so the only thing that can fail is the signature
+   * check itself; asserting {@link SignatureException} (not a broader exception) pins the rejection
+   * to that check.
+   */
+  @Test
+  void parseVerified_rejectsTokenSignedByUntrustedKey() throws Exception {
+    KeyPair untrusted = generateRsaKeyPair();
+
+    assertThatThrownBy(() -> tokenService.parseVerified(visaShapedToken(untrusted)))
+        .isInstanceOf(SignatureException.class);
+  }
+
+  /**
+   * Positive control for the rejection test: proves the trusted-key wiring works, so the forged
+   * token above fails on its signature and not on a broken fixture.
+   */
+  @Test
+  void parseVerified_returnsClaimsForTokenSignedByTrustedKey() {
+    Claims claims = tokenService.parseVerified(visaShapedToken(trusted));
+
+    assertThat(claims.getSubject()).isEqualTo("dummy@elixir-europe.org");
+  }
+
+  private String visaShapedToken(KeyPair signer) {
+    return Jwts.builder()
+        .subject("dummy@elixir-europe.org")
+        .issuer("https://login.elixir-czech.org/oidc/")
+        .expiration(new Date(32503680000000L))
+        .claim(
+            "ga4gh_visa_v1",
+            Map.of(
+                "type", "ControlledAccessGrants",
+                "asserted", 1583757401L,
+                "value", "https://ega-archive.org/datasets/EGAD00010000919",
+                "source", "https://ega-archive.org/dacs/EGAC00000000001",
+                "by", "dac"))
+        .signWith(signer.getPrivate())
+        .compact();
+  }
+
+  private static KeyPair generateRsaKeyPair() throws Exception {
+    KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(2048);
+    return kpg.generateKeyPair();
+  }
+}


### PR DESCRIPTION
Moves the C1 negative check (forged-signature token must be rejected) to where the behavior actually lives in the proxy.

## Why
C1 (an audit control) requires that a structurally valid token signed by an untrusted key is rejected. The only guard today is the slow e2e negative stage, which #833 retires. The first cut of this PR asserted the rejection on a `NimbusJwtDecoder`, but that decoder only backs the browser OIDC endpoints (`/token`, `/user`); the upload path (`/files` + `Proxy-Authorization`) is guarded by `AAIAspect` -> `TokenService.parseVerified` (jjwt). A decoder-level test proved nothing about C1: removing the `verifyWith` call in `parseVerified` would have kept it green.

## What
- `TokenServiceTest`: `parseVerified` refuses a valid, unexpired token signed by an untrusted key with a `SignatureException` specifically, plus a trusted-key positive control so the rejection cannot pass on a broken fixture.
- `AAIAspectTest`: a verifier refusal becomes HTTP 403 and the proxied call never runs (missing token is 401). Also asserts the aspect actually consults the verifier, so silently skipping verification cannot stay green.
- `JwtDecoderConfigTest`: the forged-signature decoder test now builds the production `JwtDecoderConfig` bean (cache wiring included) instead of a hand-rolled decoder, scoped to the OIDC endpoints it actually guards.

## Coverage vs the retired e2e stage
The e2e stage proved forged token -> HTTP 403 end to end. That chain is now pinned in two unit halves: signature refusal (`TokenServiceTest`) and refusal -> 403 without proceeding (`AAIAspectTest`). Runs in milliseconds on every proxy build, not only when the full e2e stack comes up.

Merge before #833 so C1 is never left uncovered.
